### PR TITLE
feat: カード読み取りAPI追加（GET /api/cards）

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/CardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/CardController.java
@@ -5,6 +5,7 @@ import com.taskmanagement.service.CardService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -15,6 +16,16 @@ public class CardController {
 
     public CardController(CardService cardService) {
         this.cardService = cardService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Card> getById(@PathVariable Long id) {
+        return ResponseEntity.ok(cardService.findById(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Card>> getByListId(@RequestParam Long listId) {
+        return ResponseEntity.ok(cardService.findByListId(listId));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/taskmanagement/model/Card.java
+++ b/backend/src/main/java/com/taskmanagement/model/Card.java
@@ -1,6 +1,7 @@
 package com.taskmanagement.model;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 
@@ -52,4 +53,8 @@ public class Card {
 
     public TaskList getList() { return list; }
     public void setList(TaskList list) { this.list = list; }
+
+    // Jackson uses @JsonProperty; non-getX name avoids Spring Data JPA property resolution conflict
+    @JsonProperty("listId")
+    public Long listId() { return list != null ? list.getId() : null; }
 }

--- a/backend/src/main/java/com/taskmanagement/service/CardService.java
+++ b/backend/src/main/java/com/taskmanagement/service/CardService.java
@@ -23,6 +23,20 @@ public class CardService {
         this.listRepository = listRepository;
     }
 
+    @Transactional(readOnly = true)
+    public Card findById(Long id) {
+        return cardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Card not found: " + id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Card> findByListId(Long listId) {
+        if (!listRepository.existsById(listId)) {
+            throw new RuntimeException("List not found: " + listId);
+        }
+        return cardRepository.findByListIdOrderByPosition(listId);
+    }
+
     public Card create(Long listId) {
         TaskList list = listRepository.findById(listId)
                 .orElseThrow(() -> new RuntimeException("List not found: " + listId));


### PR DESCRIPTION
## 概要

- `GET /api/cards/{id}` でカード単体を取得できるようにした
- `GET /api/cards?listId={id}` でリスト内カードをposition順に取得できるようにした

Closes #1

---

## 変更種別

- [x] `feat` — 新機能

---

## 影響範囲

- [x] バックエンド (Spring Boot)

---

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `CardController.java` | `GET /{id}` と `GET ?listId=` エンドポイントを追加 |
| `CardService.java` | `findById` / `findByListId` メソッドを追加 |
| `Card.java` | `listId` をJSONレスポンスに含めるよう追加 |

---

## テスト手順

- [x] `docker compose up -d` でDB起動（またはローカルPostgreSQL）
- [x] `./gradlew bootRun` でバックエンド起動
- [x] `curl http://localhost:8080/api/cards/1` → カード単体取得を確認
- [x] `curl "http://localhost:8080/api/cards?listId=1"` → リストのカード一覧取得を確認

---

## チェックリスト

- [x] ブランチ名が `feature/issue-1-add-card-read-api` 形式
- [x] コミットに `Refs #1` が含まれている
- [x] `Closes #1` が含まれている
- [x] `.env` やシークレットなし