### PR TITLE
chore: ボードCRUD追加・DB設定環境変数化・docker-compose追加

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardController.java
@@ -5,6 +5,8 @@ import com.taskmanagement.repository.BoardRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/boards")
 public class BoardController {
@@ -15,10 +17,29 @@ public class BoardController {
         this.boardRepository = boardRepository;
     }
 
+    @GetMapping
+    public List<Board> getAllBoards() {
+        return boardRepository.findAll();
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<Board> getBoard(@PathVariable Long id) {
         return boardRepository.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Board createBoard(@RequestBody Board board) {
+        return boardRepository.save(board);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBoard(@PathVariable Long id) {
+        if (!boardRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        boardRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/taskmanagement
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:taskmanagement}
+spring.datasource.username=${DB_USER:postgres}
+spring.datasource.password=${DB_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
@@ -8,4 +8,4 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
-server.port=8080
+server.port=${SERVER_PORT:8080}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: taskmanagement-db
+    environment:
+      POSTGRES_DB: taskmanagement
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d taskmanagement"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## 概要

- `BoardController` に一覧取得・作成・削除エンドポイントを追加
- `application.properties` のDB接続情報を環境変数化（Docker/本番環境対応）
- `docker-compose.yml` を追加（PostgreSQL 16 ローカル起動用）

Closes #3

---

## 変更種別

- [x] `chore` — リファクタリング・設定・依存関係

---

## 影響範囲

- [x] バックエンド (Spring Boot)
- [x] Docker / インフラ

---

## 変更詳細

| ファイル | 変更内容 |
|---|---|
| `BoardController.java` | `GET /api/boards`（一覧）・`POST /api/boards`・`DELETE /api/boards/{id}` を追加 |
| `application.properties` | `localhost:5432` → `${DB_HOST:localhost}` 等の環境変数形式に変更 |
| `docker-compose.yml` | PostgreSQL 16-alpine の起動設定を新規追加 |

---

## テスト手順

- [x] `docker compose up -d` → `./gradlew bootRun` で起動確認済み
- [x] `curl http://localhost:8080/api/boards` でボード一覧が返ることを確認済み

---

## チェックリスト

- [x] ブランチ名が `chore/issue-3-setup-board-crud-and-docker-config` 形式
- [x] コミットに `Refs #3` が含まれている
- [x] `Closes #3` が含まれている
- [x] `.env` やシークレットなし