### PR TITLE
fix: ドラッグ後にカードが斜めのまま残るバグを修正

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -266,7 +266,6 @@ body {
 
 .sortable-chosen {
   box-shadow: 0 8px 24px rgba(0,0,0,0.25) !important;
-  transform: rotate(1.5deg) translateY(-2px) !important;
 }
 
 /* ===== MODAL ===== */


### PR DESCRIPTION
## 概要

Closes #5

## 変更内容

- `App.css` の `.sortable-chosen` から `transform: rotate(1.5deg) translateY(-2px) !important` を削除

## 原因

`.sortable-chosen` に設定していた `!important` 付きの `transform` が、`@hello-pangea/dnd` がドロップアニメーション時にセットするインライン `transform` を上書きしていた。そのためドロップ後にライブラリの状態が壊れ、カードが回転したまま残ることがあった。

## テスト

- [ ] カードをドラッグして別のリストに移動 → ドロップ後に斜めにならないことを確認
- [ ] ドラッグ中は影（box-shadow）が表示されることを確認