### PR TITLE
fix: ドラッグ中のカード斜め・移動不可バグを修正

### DIFF
--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -20,34 +20,37 @@ export default function Card({ card, index, onEdit, onDelete }) {
     <Draggable draggableId={String(card.id)} index={index}>
       {(provided, snapshot) => (
         <div
-          className={`card ${snapshot.isDragging ? 'sortable-chosen' : ''}`}
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          onClick={(e) => { if (!e.target.closest('button')) onEdit(card) }}
         >
-          <div className="card-header">
-            <span className="card-title">{card.title || '無題のカード'}</span>
-            <button
-              className="btn-delete-card"
-              onClick={e => { e.stopPropagation(); onDelete(card.id) }}
-              title="カードを削除"
-            >×</button>
-          </div>
-          {(card.dueDate || card.priority) && (
-            <div className="card-meta">
-              {card.dueDate && (
-                <span className={`card-due ${isOverdue(card.dueDate) ? 'overdue' : ''}`}>
-                  📅 {formatDate(card.dueDate)}
-                </span>
-              )}
-              {card.priority && (
-                <span className={`priority-badge ${card.priority}`}>
-                  {PRIORITY_LABEL[card.priority]}
-                </span>
-              )}
+          <div
+            className={`card ${snapshot.isDragging ? 'sortable-chosen' : ''}`}
+            onClick={(e) => { if (!e.target.closest('button')) onEdit(card) }}
+          >
+            <div className="card-header">
+              <span className="card-title">{card.title || '無題のカード'}</span>
+              <button
+                className="btn-delete-card"
+                onClick={e => { e.stopPropagation(); onDelete(card.id) }}
+                title="カードを削除"
+              >×</button>
             </div>
-          )}
+            {(card.dueDate || card.priority) && (
+              <div className="card-meta">
+                {card.dueDate && (
+                  <span className={`card-due ${isOverdue(card.dueDate) ? 'overdue' : ''}`}>
+                    📅 {formatDate(card.dueDate)}
+                  </span>
+                )}
+                {card.priority && (
+                  <span className={`priority-badge ${card.priority}`}>
+                    {PRIORITY_LABEL[card.priority]}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </Draggable>


### PR DESCRIPTION
## 概要

カードをドラッグすると斜めになり、他のカードと入れ替えられないバグを修正。

## 原因

`Card.jsx` で `ref={provided.innerRef}` / `draggableProps` と `className="card"` が同じ div に混在していたことが問題。

- `@hello-pangea/dnd` は draggableProps の `style` に `transform: translate(x, y)` を inline で設定してカードを追従させる
- App.css の `.card` / `.card:hover` には `transition: transform 0.1s` と `transform: translateY(-1px)` が定義されていた
- CSS の transform transition が dnd の inline transform に干渉し、カードが正しい位置に追従しない → 斜め/移動不可の挙動が発生

## 修正内容

`Card.jsx` で外側 div と内側 div を分離:
- **外側 div**: `ref`, `draggableProps`, `dragHandleProps` のみ — dnd が位置制御（transform）を担当
- **内側 div**: `className="card"` — ホバーエフェクト等のビジュアルを担当

これにより CSS の transition/transform は内側 div にだけ適用され、dnd の位置計算と競合しない。

## テスト

- [x] カードを同一リスト内でドラッグして並び替えできる
- [x] カードを別リストへドラッグ&ドロップできる
- [x] ドラッグ中にカードが斜めにならない

Closes #10