### PR TITLE
feat: ユーザー登録・ログイン機能を追加

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,6 +20,10 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly    'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly    'io.jsonwebtoken:jjwt-jackson:0.12.6'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/src/main/java/com/taskmanagement/config/CorsConfig.java
+++ b/backend/src/main/java/com/taskmanagement/config/CorsConfig.java
@@ -1,17 +1,4 @@
 package com.taskmanagement.config;
 
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-@Configuration
-public class CorsConfig implements WebMvcConfigurer {
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PUT", "DELETE")
-                .allowedHeaders("*");
-    }
-}
+// CORS configuration has been moved to SecurityConfig to work correctly with Spring Security.
+// This file is kept empty to avoid breaking git history.

--- a/backend/src/main/java/com/taskmanagement/config/SecurityConfig.java
+++ b/backend/src/main/java/com/taskmanagement/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.taskmanagement.config;
+
+import com.taskmanagement.security.JwtAuthFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", config);
+        return source;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/AuthController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.AuthResponse;
+import com.taskmanagement.dto.LoginRequest;
+import com.taskmanagement.dto.RegisterRequest;
+import com.taskmanagement.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@RequestBody RegisterRequest req) {
+        return ResponseEntity.ok(authService.register(req));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest req) {
+        return ResponseEntity.ok(authService.login(req));
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardController.java
@@ -21,7 +21,7 @@ public class BoardController {
     @GetMapping
     public List<Board> getMyBoards(Authentication auth) {
         Long userId = (Long) auth.getPrincipal();
-        return boardRepository.findByUserId(userId);
+        return boardRepository.findByUser_Id(userId);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/taskmanagement/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.taskmanagement.controller;
 import com.taskmanagement.model.Board;
 import com.taskmanagement.repository.BoardRepository;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,13 +19,16 @@ public class BoardController {
     }
 
     @GetMapping
-    public List<Board> getAllBoards() {
-        return boardRepository.findAll();
+    public List<Board> getMyBoards(Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        return boardRepository.findByUserId(userId);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Board> getBoard(@PathVariable Long id) {
+    public ResponseEntity<Board> getBoard(@PathVariable Long id, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
         return boardRepository.findById(id)
+                .filter(b -> b.getUser() != null && b.getUser().getId().equals(userId))
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -35,11 +39,14 @@ public class BoardController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteBoard(@PathVariable Long id) {
-        if (!boardRepository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        boardRepository.deleteById(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<Void> deleteBoard(@PathVariable Long id, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        return boardRepository.findById(id)
+                .filter(b -> b.getUser() != null && b.getUser().getId().equals(userId))
+                .<ResponseEntity<Void>>map(b -> {
+                    boardRepository.delete(b);
+                    return ResponseEntity.<Void>noContent().build();
+                })
+                .orElse(ResponseEntity.<Void>notFound().build());
     }
 }

--- a/backend/src/main/java/com/taskmanagement/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/taskmanagement/controller/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.taskmanagement.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleRuntime(RuntimeException ex) {
+        return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/PasskeyController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/PasskeyController.java
@@ -1,0 +1,33 @@
+package com.taskmanagement.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth/passkey")
+public class PasskeyController {
+
+    // WebAuthn full implementation is planned for a future issue.
+
+    @PostMapping("/registration/options")
+    public ResponseEntity<Map<String, String>> registrationOptions() {
+        return ResponseEntity.status(501).body(Map.of("message", "パスキー登録は現在準備中です"));
+    }
+
+    @PostMapping("/registration/verify")
+    public ResponseEntity<Map<String, String>> registrationVerify(@RequestBody Map<String, Object> body) {
+        return ResponseEntity.status(501).body(Map.of("message", "パスキー登録は現在準備中です"));
+    }
+
+    @PostMapping("/authentication/options")
+    public ResponseEntity<Map<String, String>> authenticationOptions() {
+        return ResponseEntity.status(501).body(Map.of("message", "パスキー認証は現在準備中です"));
+    }
+
+    @PostMapping("/authentication/verify")
+    public ResponseEntity<Map<String, String>> authenticationVerify(@RequestBody Map<String, Object> body) {
+        return ResponseEntity.status(501).body(Map.of("message", "パスキー認証は現在準備中です"));
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/UserController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/UserController.java
@@ -1,0 +1,76 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.AuthResponse;
+import com.taskmanagement.dto.ChangePasswordRequest;
+import com.taskmanagement.dto.UpdateProfileRequest;
+import com.taskmanagement.model.User;
+import com.taskmanagement.repository.UserRepository;
+import com.taskmanagement.security.JwtUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserRepository userRepo;
+    private final BCryptPasswordEncoder encoder;
+    private final JwtUtil jwtUtil;
+
+    public UserController(UserRepository userRepo, BCryptPasswordEncoder encoder, JwtUtil jwtUtil) {
+        this.userRepo = userRepo;
+        this.encoder = encoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<AuthResponse> getMe(Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+        return ResponseEntity.ok(new AuthResponse(null, user.getId(), user.getUsername(), user.getEmail()));
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<AuthResponse> updateProfile(@RequestBody UpdateProfileRequest req, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+
+        if (req.getUsername() != null && !req.getUsername().isBlank()) {
+            if (!req.getUsername().matches("[a-zA-Z0-9_]{3,50}"))
+                throw new RuntimeException("ユーザー名は英数字・アンダースコアで3〜50文字にしてください");
+            if (!req.getUsername().equals(user.getUsername()) && userRepo.existsByUsername(req.getUsername()))
+                throw new RuntimeException("このユーザー名はすでに使用されています");
+            user.setUsername(req.getUsername());
+        }
+
+        if (req.getEmail() != null && !req.getEmail().isBlank()) {
+            if (!req.getEmail().equals(user.getEmail()) && userRepo.existsByEmail(req.getEmail()))
+                throw new RuntimeException("このメールアドレスはすでに登録されています");
+            user.setEmail(req.getEmail());
+        }
+
+        userRepo.save(user);
+        String token = jwtUtil.generateToken(user.getId(), user.getUsername());
+        return ResponseEntity.ok(new AuthResponse(token, user.getId(), user.getUsername(), user.getEmail()));
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> changePassword(@RequestBody ChangePasswordRequest req, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+
+        if (req.getCurrentPassword() == null || !encoder.matches(req.getCurrentPassword(), user.getPasswordHash()))
+            throw new RuntimeException("現在のパスワードが正しくありません");
+        if (req.getNewPassword() == null || req.getNewPassword().length() < 8)
+            throw new RuntimeException("新しいパスワードは8文字以上で入力してください");
+
+        user.setPasswordHash(encoder.encode(req.getNewPassword()));
+        userRepo.save(user);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/AuthResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/AuthResponse.java
@@ -1,0 +1,20 @@
+package com.taskmanagement.dto;
+
+public class AuthResponse {
+    private String token;
+    private Long userId;
+    private String username;
+    private String email;
+
+    public AuthResponse(String token, Long userId, String username, String email) {
+        this.token = token;
+        this.userId = userId;
+        this.username = username;
+        this.email = email;
+    }
+
+    public String getToken() { return token; }
+    public Long getUserId() { return userId; }
+    public String getUsername() { return username; }
+    public String getEmail() { return email; }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/ChangePasswordRequest.java
@@ -1,0 +1,12 @@
+package com.taskmanagement.dto;
+
+public class ChangePasswordRequest {
+    private String currentPassword;
+    private String newPassword;
+
+    public String getCurrentPassword() { return currentPassword; }
+    public void setCurrentPassword(String currentPassword) { this.currentPassword = currentPassword; }
+
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/LoginRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.taskmanagement.dto;
+
+public class LoginRequest {
+    private String identifier;
+    private String password;
+
+    public String getIdentifier() { return identifier; }
+    public void setIdentifier(String identifier) { this.identifier = identifier; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/RegisterRequest.java
@@ -1,0 +1,16 @@
+package com.taskmanagement.dto;
+
+public class RegisterRequest {
+    private String username;
+    private String email;
+    private String password;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/UpdateProfileRequest.java
@@ -1,0 +1,12 @@
+package com.taskmanagement.dto;
+
+public class UpdateProfileRequest {
+    private String username;
+    private String email;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+}

--- a/backend/src/main/java/com/taskmanagement/model/Board.java
+++ b/backend/src/main/java/com/taskmanagement/model/Board.java
@@ -1,6 +1,8 @@
 package com.taskmanagement.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.taskmanagement.model.User;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +18,11 @@ public class Board {
     @Column(nullable = false)
     private String title;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @JsonIgnore
+    private User user;
+
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("position ASC")
     @JsonManagedReference("board-lists")
@@ -26,6 +33,11 @@ public class Board {
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Long getUserId() { return user != null ? user.getId() : null; }
 
     public List<TaskList> getLists() { return lists; }
     public void setLists(List<TaskList> lists) { this.lists = lists; }

--- a/backend/src/main/java/com/taskmanagement/model/PasskeyCredential.java
+++ b/backend/src/main/java/com/taskmanagement/model/PasskeyCredential.java
@@ -1,0 +1,47 @@
+package com.taskmanagement.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "passkey_credentials")
+public class PasskeyCredential {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "credential_id", nullable = false, unique = true)
+    private String credentialId;
+
+    @Column(name = "public_key_cose", nullable = false)
+    private byte[] publicKeyCose;
+
+    @Column(name = "sign_count", nullable = false)
+    private long signCount = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public String getCredentialId() { return credentialId; }
+    public void setCredentialId(String credentialId) { this.credentialId = credentialId; }
+
+    public byte[] getPublicKeyCose() { return publicKeyCose; }
+    public void setPublicKeyCose(byte[] publicKeyCose) { this.publicKeyCose = publicKeyCose; }
+
+    public long getSignCount() { return signCount; }
+    public void setSignCount(long signCount) { this.signCount = signCount; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/taskmanagement/model/User.java
+++ b/backend/src/main/java/com/taskmanagement/model/User.java
@@ -1,0 +1,40 @@
+package com.taskmanagement.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash")
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/taskmanagement/repository/BoardRepository.java
+++ b/backend/src/main/java/com/taskmanagement/repository/BoardRepository.java
@@ -3,5 +3,8 @@ package com.taskmanagement.repository;
 import com.taskmanagement.model.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    List<Board> findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/taskmanagement/repository/BoardRepository.java
+++ b/backend/src/main/java/com/taskmanagement/repository/BoardRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    List<Board> findByUserId(Long userId);
+    List<Board> findByUser_Id(Long userId);
 }

--- a/backend/src/main/java/com/taskmanagement/repository/UserRepository.java
+++ b/backend/src/main/java/com/taskmanagement/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.taskmanagement.repository;
+
+import com.taskmanagement.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/taskmanagement/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/taskmanagement/security/JwtAuthFilter.java
@@ -1,0 +1,40 @@
+package com.taskmanagement.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtUtil.validateToken(token)) {
+                Long userId = jwtUtil.extractUserId(token);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/security/JwtUtil.java
+++ b/backend/src/main/java/com/taskmanagement/security/JwtUtil.java
@@ -1,0 +1,58 @@
+package com.taskmanagement.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${app.jwt.secret}")
+    private String secret;
+
+    @Value("${app.jwt.expiration-ms}")
+    private long expirationMs;
+
+    private SecretKey key() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Long userId, String username) {
+        return Jwts.builder()
+                .subject(username)
+                .claim("userId", userId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(key())
+                .compact();
+    }
+
+    public Long extractUserId(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("userId", Long.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/service/AuthService.java
+++ b/backend/src/main/java/com/taskmanagement/service/AuthService.java
@@ -1,0 +1,80 @@
+package com.taskmanagement.service;
+
+import com.taskmanagement.dto.AuthResponse;
+import com.taskmanagement.dto.LoginRequest;
+import com.taskmanagement.dto.RegisterRequest;
+import com.taskmanagement.model.Board;
+import com.taskmanagement.model.User;
+import com.taskmanagement.repository.BoardRepository;
+import com.taskmanagement.repository.UserRepository;
+import com.taskmanagement.security.JwtUtil;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+public class AuthService {
+
+    private final UserRepository userRepo;
+    private final BoardRepository boardRepo;
+    private final BCryptPasswordEncoder encoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(UserRepository userRepo, BoardRepository boardRepo,
+                       BCryptPasswordEncoder encoder, JwtUtil jwtUtil) {
+        this.userRepo = userRepo;
+        this.boardRepo = boardRepo;
+        this.encoder = encoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public AuthResponse register(RegisterRequest req) {
+        if (req.getUsername() == null || req.getUsername().isBlank())
+            throw new RuntimeException("ユーザー名を入力してください");
+        if (req.getEmail() == null || req.getEmail().isBlank())
+            throw new RuntimeException("メールアドレスを入力してください");
+        if (req.getPassword() == null || req.getPassword().length() < 8)
+            throw new RuntimeException("パスワードは8文字以上で入力してください");
+        if (!req.getUsername().matches("[a-zA-Z0-9_]{3,50}"))
+            throw new RuntimeException("ユーザー名は英数字・アンダースコアで3〜50文字にしてください");
+
+        if (userRepo.existsByUsername(req.getUsername()))
+            throw new RuntimeException("このユーザー名はすでに使用されています");
+        if (userRepo.existsByEmail(req.getEmail()))
+            throw new RuntimeException("このメールアドレスはすでに登録されています");
+
+        User user = new User();
+        user.setUsername(req.getUsername());
+        user.setEmail(req.getEmail());
+        user.setPasswordHash(encoder.encode(req.getPassword()));
+        userRepo.save(user);
+
+        Board board = new Board();
+        board.setTitle("マイボード");
+        board.setUser(user);
+        boardRepo.save(board);
+
+        String token = jwtUtil.generateToken(user.getId(), user.getUsername());
+        return new AuthResponse(token, user.getId(), user.getUsername(), user.getEmail());
+    }
+
+    public AuthResponse login(LoginRequest req) {
+        if (req.getIdentifier() == null || req.getIdentifier().isBlank())
+            throw new RuntimeException("ユーザー名またはメールアドレスを入力してください");
+
+        Optional<User> userOpt = req.getIdentifier().contains("@")
+                ? userRepo.findByEmail(req.getIdentifier())
+                : userRepo.findByUsername(req.getIdentifier());
+
+        User user = userOpt.orElseThrow(() -> new RuntimeException("ユーザー名またはパスワードが正しくありません"));
+
+        if (user.getPasswordHash() == null || !encoder.matches(req.getPassword(), user.getPasswordHash()))
+            throw new RuntimeException("ユーザー名またはパスワードが正しくありません");
+
+        String token = jwtUtil.generateToken(user.getId(), user.getUsername());
+        return new AuthResponse(token, user.getId(), user.getUsername(), user.getEmail());
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
 server.port=${SERVER_PORT:8080}
+
+app.jwt.secret=${JWT_SECRET:dev-secret-key-change-in-production-must-be-32chars!}
+app.jwt.expiration-ms=86400000

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -19,3 +19,23 @@ CREATE TABLE IF NOT EXISTS cards (
     priority    VARCHAR(10),
     position    INTEGER      NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS users (
+    id            BIGSERIAL    PRIMARY KEY,
+    username      VARCHAR(50)  NOT NULL UNIQUE,
+    email         VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255),
+    created_at    TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    credential_id   TEXT      NOT NULL UNIQUE,
+    public_key_cose BYTEA     NOT NULL,
+    sign_count      BIGINT    NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE boards
+    ADD COLUMN IF NOT EXISTS user_id BIGINT REFERENCES users(id) ON DELETE CASCADE;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "@hello-pangea/dnd": "^18.0.1",
         "axios": "^1.15.2",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1143,6 +1144,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2492,6 +2506,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -2554,6 +2606,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@hello-pangea/dnd": "^18.0.1",
     "axios": "^1.15.2",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,125 +3,139 @@ import { DragDropContext } from '@hello-pangea/dnd'
 import List from './components/List'
 import CardModal from './components/CardModal'
 import {
-  getBoard, createList, updateList, deleteList,
-  createCard, updateCard, deleteCard, moveCard
+    getMyBoards, getBoard, createList, updateList, deleteList,
+    createCard, updateCard, deleteCard, moveCard
 } from './api/client'
+import { useAuth } from './auth/AuthContext'
 import './App.css'
 
-const BOARD_ID = 1
-
 export default function App() {
-  const [board, setBoard] = useState(null)
-  const [editingCard, setEditingCard] = useState(null)
+    const [board, setBoard] = useState(null)
+    const [editingCard, setEditingCard] = useState(null)
+    const { auth, logout } = useAuth()
 
-  const loadBoard = useCallback(() => {
-    getBoard(BOARD_ID).then(setBoard).catch(console.error)
-  }, [])
+    const loadBoard = useCallback(() => {
+        getMyBoards()
+            .then(boards => boards.length > 0 ? getBoard(boards[0].id) : null)
+            .then(setBoard)
+            .catch(console.error)
+    }, [])
 
-  useEffect(() => { loadBoard() }, [loadBoard])
+    useEffect(() => { loadBoard() }, [loadBoard])
 
-  async function handleAddList() {
-    const list = await createList(BOARD_ID, '新しいリスト')
-    setBoard(prev => ({ ...prev, lists: [...prev.lists, { ...list, cards: [] }] }))
-  }
+    async function handleAddList() {
+        if (!board) return
+        const list = await createList(board.id, '新しいリスト')
+        setBoard(prev => ({ ...prev, lists: [...prev.lists, { ...list, cards: [] }] }))
+    }
 
-  async function handleDeleteList(listId) {
-    await deleteList(listId)
-    setBoard(prev => ({ ...prev, lists: prev.lists.filter(l => l.id !== listId) }))
-  }
+    async function handleDeleteList(listId) {
+        await deleteList(listId)
+        setBoard(prev => ({ ...prev, lists: prev.lists.filter(l => l.id !== listId) }))
+    }
 
-  async function handleRenameList(listId, title) {
-    const updated = await updateList(listId, title)
-    setBoard(prev => ({
-      ...prev,
-      lists: prev.lists.map(l => l.id === listId ? { ...l, title: updated.title } : l)
-    }))
-  }
+    async function handleRenameList(listId, title) {
+        const updated = await updateList(listId, title)
+        setBoard(prev => ({
+            ...prev,
+            lists: prev.lists.map(l => l.id === listId ? { ...l, title: updated.title } : l)
+        }))
+    }
 
-  async function handleAddCard(listId) {
-    const card = await createCard(listId)
-    setBoard(prev => ({
-      ...prev,
-      lists: prev.lists.map(l =>
-        l.id === listId ? { ...l, cards: [...l.cards, card] } : l
-      )
-    }))
-    setEditingCard(card)
-  }
+    async function handleAddCard(listId) {
+        const card = await createCard(listId)
+        setBoard(prev => ({
+            ...prev,
+            lists: prev.lists.map(l =>
+                l.id === listId ? { ...l, cards: [...l.cards, card] } : l
+            )
+        }))
+        setEditingCard(card)
+    }
 
-  async function handleDeleteCard(cardId) {
-    await deleteCard(cardId)
-    setBoard(prev => ({
-      ...prev,
-      lists: prev.lists.map(l => ({ ...l, cards: l.cards.filter(c => c.id !== cardId) }))
-    }))
-  }
+    async function handleDeleteCard(cardId) {
+        await deleteCard(cardId)
+        setBoard(prev => ({
+            ...prev,
+            lists: prev.lists.map(l => ({ ...l, cards: l.cards.filter(c => c.id !== cardId) }))
+        }))
+    }
 
-  async function handleSaveCard(data) {
-    const updated = await updateCard(editingCard.id, data)
-    setBoard(prev => ({
-      ...prev,
-      lists: prev.lists.map(l => ({
-        ...l,
-        cards: l.cards.map(c => c.id === updated.id ? updated : c)
-      }))
-    }))
-    setEditingCard(null)
-  }
+    async function handleSaveCard(data) {
+        const updated = await updateCard(editingCard.id, data)
+        setBoard(prev => ({
+            ...prev,
+            lists: prev.lists.map(l => ({
+                ...l,
+                cards: l.cards.map(c => c.id === updated.id ? updated : c)
+            }))
+        }))
+        setEditingCard(null)
+    }
 
-  async function handleDragEnd(result) {
-    const { source, destination, draggableId } = result
-    if (!destination) return
-    if (source.droppableId === destination.droppableId && source.index === destination.index) return
+    async function handleDragEnd(result) {
+        const { source, destination, draggableId } = result
+        if (!destination) return
+        if (source.droppableId === destination.droppableId && source.index === destination.index) return
 
-    const cardId = parseInt(draggableId)
-    const toListId = parseInt(destination.droppableId)
+        const cardId = parseInt(draggableId)
+        const toListId = parseInt(destination.droppableId)
 
-    // Optimistic UI update
-    setBoard(prev => {
-      const lists = prev.lists.map(l => ({ ...l, cards: [...l.cards] }))
-      const fromList = lists.find(l => l.id === parseInt(source.droppableId))
-      const toList = lists.find(l => l.id === toListId)
-      const [card] = fromList.cards.splice(source.index, 1)
-      toList.cards.splice(destination.index, 0, card)
-      return { ...prev, lists }
-    })
+        setBoard(prev => {
+            const lists = prev.lists.map(l => ({ ...l, cards: [...l.cards] }))
+            const fromList = lists.find(l => l.id === parseInt(source.droppableId))
+            const toList = lists.find(l => l.id === toListId)
+            const [card] = fromList.cards.splice(source.index, 1)
+            toList.cards.splice(destination.index, 0, card)
+            return { ...prev, lists }
+        })
 
-    await moveCard(cardId, toListId, destination.index)
-  }
+        await moveCard(cardId, toListId, destination.index)
+    }
 
-  if (!board) return <div style={{ padding: 24, color: '#666' }}>読み込み中...</div>
+    if (!board) return <div style={{ padding: 24, color: '#666' }}>読み込み中...</div>
 
-  return (
-    <>
-      <header id="app-header">
-        <h1 id="app-title">📋 タスク管理アプリ</h1>
-        <button id="btn-add-list" onClick={handleAddList}>＋ リスト追加</button>
-      </header>
+    return (
+        <>
+            <header id="app-header">
+                <h1 id="app-title">📋 タスク管理アプリ</h1>
+                <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+                    <span style={{ color: '#fff', fontSize: '0.9rem' }}>
+                        {auth?.user?.username}
+                    </span>
+                    <button
+                        style={{ background: 'rgba(255,255,255,0.2)', border: 'none', color: '#fff', padding: '6px 12px', borderRadius: 6, cursor: 'pointer' }}
+                        onClick={logout}
+                    >
+                        ログアウト
+                    </button>
+                    <button id="btn-add-list" onClick={handleAddList}>＋ リスト追加</button>
+                </div>
+            </header>
 
-      <DragDropContext onDragEnd={handleDragEnd}>
-        <main id="board">
-          {board.lists.map(list => (
-            <List
-              key={list.id}
-              list={list}
-              onAddCard={handleAddCard}
-              onDeleteList={handleDeleteList}
-              onRenameList={handleRenameList}
-              onEditCard={setEditingCard}
-              onDeleteCard={handleDeleteCard}
-            />
-          ))}
-        </main>
-      </DragDropContext>
+            <DragDropContext onDragEnd={handleDragEnd}>
+                <main id="board">
+                    {board.lists.map(list => (
+                        <List
+                            key={list.id}
+                            list={list}
+                            onAddCard={handleAddCard}
+                            onDeleteList={handleDeleteList}
+                            onRenameList={handleRenameList}
+                            onEditCard={setEditingCard}
+                            onDeleteCard={handleDeleteCard}
+                        />
+                    ))}
+                </main>
+            </DragDropContext>
 
-      {editingCard && (
-        <CardModal
-          card={editingCard}
-          onSave={handleSaveCard}
-          onClose={() => setEditingCard(null)}
-        />
-      )}
-    </>
-  )
+            {editingCard && (
+                <CardModal
+                    card={editingCard}
+                    onSave={handleSaveCard}
+                    onClose={() => setEditingCard(null)}
+                />
+            )}
+        </>
+    )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { DragDropContext } from '@hello-pangea/dnd'
 import List from './components/List'
 import CardModal from './components/CardModal'
+import AccountSettingsModal from './components/AccountSettingsModal'
 import {
     getMyBoards, getBoard, createList, updateList, deleteList,
     createCard, updateCard, deleteCard, moveCard
@@ -12,6 +13,7 @@ import './App.css'
 export default function App() {
     const [board, setBoard] = useState(null)
     const [editingCard, setEditingCard] = useState(null)
+    const [showSettings, setShowSettings] = useState(false)
     const { auth, logout } = useAuth()
 
     const loadBoard = useCallback(() => {
@@ -100,11 +102,15 @@ export default function App() {
             <header id="app-header">
                 <h1 id="app-title">📋 タスク管理アプリ</h1>
                 <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-                    <span style={{ color: '#fff', fontSize: '0.9rem' }}>
-                        {auth?.user?.username}
-                    </span>
                     <button
-                        style={{ background: 'rgba(255,255,255,0.2)', border: 'none', color: '#fff', padding: '6px 12px', borderRadius: 6, cursor: 'pointer' }}
+                        className="header-user-btn"
+                        onClick={() => setShowSettings(true)}
+                        title="アカウント設定"
+                    >
+                        {auth?.user?.username}
+                    </button>
+                    <button
+                        className="header-ghost-btn"
                         onClick={logout}
                     >
                         ログアウト
@@ -135,6 +141,10 @@ export default function App() {
                     onSave={handleSaveCard}
                     onClose={() => setEditingCard(null)}
                 />
+            )}
+
+            {showSettings && (
+                <AccountSettingsModal onClose={() => setShowSettings(false)} />
             )}
         </>
     )

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -23,6 +23,10 @@ api.interceptors.response.use(
 export const register = (data) => api.post('/auth/register', data).then(r => r.data)
 export const loginApi = (data) => api.post('/auth/login', data).then(r => r.data)
 
+export const getMe = () => api.get('/user/me').then(r => r.data)
+export const updateProfile = (data) => api.put('/user/profile', data).then(r => r.data)
+export const changePassword = (data) => api.put('/user/password', data)
+
 export const getMyBoards = () => api.get('/boards').then(r => r.data)
 export const getBoard = (id) => api.get(`/boards/${id}`).then(r => r.data)
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -2,25 +2,47 @@ import axios from 'axios'
 
 const api = axios.create({ baseURL: '/api' })
 
+api.interceptors.request.use(config => {
+    const token = localStorage.getItem('token')
+    if (token) config.headers.Authorization = `Bearer ${token}`
+    return config
+})
+
+api.interceptors.response.use(
+    res => res,
+    err => {
+        if (err.response?.status === 401) {
+            localStorage.removeItem('token')
+            localStorage.removeItem('user')
+            window.location.href = '/login'
+        }
+        return Promise.reject(err)
+    }
+)
+
+export const register = (data) => api.post('/auth/register', data).then(r => r.data)
+export const loginApi = (data) => api.post('/auth/login', data).then(r => r.data)
+
+export const getMyBoards = () => api.get('/boards').then(r => r.data)
 export const getBoard = (id) => api.get(`/boards/${id}`).then(r => r.data)
 
 export const createList = (boardId, title) =>
-  api.post('/lists', { boardId, title }).then(r => r.data)
+    api.post('/lists', { boardId, title }).then(r => r.data)
 
 export const updateList = (id, title) =>
-  api.put(`/lists/${id}`, { title }).then(r => r.data)
+    api.put(`/lists/${id}`, { title }).then(r => r.data)
 
 export const deleteList = (id) => api.delete(`/lists/${id}`)
 
 export const reorderLists = (items) => api.put('/lists/reorder', items)
 
 export const createCard = (listId) =>
-  api.post('/cards', { listId }).then(r => r.data)
+    api.post('/cards', { listId }).then(r => r.data)
 
 export const updateCard = (id, data) =>
-  api.put(`/cards/${id}`, data).then(r => r.data)
+    api.put(`/cards/${id}`, data).then(r => r.data)
 
 export const deleteCard = (id) => api.delete(`/cards/${id}`)
 
 export const moveCard = (id, toListId, position) =>
-  api.put(`/cards/${id}/move`, { toListId, position }).then(r => r.data)
+    api.put(`/cards/${id}/move`, { toListId, position }).then(r => r.data)

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -21,8 +21,14 @@ export function AuthProvider({ children }) {
         setAuth(null)
     }, [])
 
+    const updateUser = useCallback((token, user) => {
+        localStorage.setItem('token', token)
+        localStorage.setItem('user', JSON.stringify(user))
+        setAuth({ token, user })
+    }, [])
+
     return (
-        <AuthContext.Provider value={{ auth, login, logout }}>
+        <AuthContext.Provider value={{ auth, login, logout, updateUser }}>
             {children}
         </AuthContext.Provider>
     )

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState, useCallback } from 'react'
+
+const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+    const [auth, setAuth] = useState(() => {
+        const token = localStorage.getItem('token')
+        const user = localStorage.getItem('user')
+        return token ? { token, user: JSON.parse(user) } : null
+    })
+
+    const login = useCallback((token, user) => {
+        localStorage.setItem('token', token)
+        localStorage.setItem('user', JSON.stringify(user))
+        setAuth({ token, user })
+    }, [])
+
+    const logout = useCallback(() => {
+        localStorage.removeItem('token')
+        localStorage.removeItem('user')
+        setAuth(null)
+    }, [])
+
+    return (
+        <AuthContext.Provider value={{ auth, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/frontend/src/auth/ProtectedRoute.jsx
+++ b/frontend/src/auth/ProtectedRoute.jsx
@@ -1,0 +1,7 @@
+import { Navigate } from 'react-router-dom'
+import { useAuth } from './AuthContext'
+
+export default function ProtectedRoute({ children }) {
+    const { auth } = useAuth()
+    return auth ? children : <Navigate to="/login" replace />
+}

--- a/frontend/src/components/AccountSettingsModal.jsx
+++ b/frontend/src/components/AccountSettingsModal.jsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+import { updateProfile, changePassword } from '../api/client'
+import { useAuth } from '../auth/AuthContext'
+
+export default function AccountSettingsModal({ onClose }) {
+    const { auth, updateUser } = useAuth()
+    const [tab, setTab] = useState('profile')
+
+    const [username, setUsername] = useState(auth?.user?.username || '')
+    const [email, setEmail] = useState(auth?.user?.email || '')
+    const [profileMsg, setProfileMsg] = useState(null)
+    const [profileLoading, setProfileLoading] = useState(false)
+
+    const [currentPassword, setCurrentPassword] = useState('')
+    const [newPassword, setNewPassword] = useState('')
+    const [confirmPassword, setConfirmPassword] = useState('')
+    const [passwordMsg, setPasswordMsg] = useState(null)
+    const [passwordLoading, setPasswordLoading] = useState(false)
+
+    async function handleProfileSave(e) {
+        e.preventDefault()
+        setProfileMsg(null)
+        if (!username.match(/^[a-zA-Z0-9_]{3,50}$/)) {
+            setProfileMsg({ type: 'error', text: 'ユーザー名は英数字・アンダースコアで3〜50文字にしてください' })
+            return
+        }
+        setProfileLoading(true)
+        try {
+            const data = await updateProfile({ username, email })
+            updateUser(data.token, { id: data.userId, username: data.username, email: data.email })
+            setProfileMsg({ type: 'success', text: 'プロフィールを更新しました' })
+        } catch (err) {
+            setProfileMsg({ type: 'error', text: err.response?.data?.message || '更新に失敗しました' })
+        } finally {
+            setProfileLoading(false)
+        }
+    }
+
+    async function handlePasswordSave(e) {
+        e.preventDefault()
+        setPasswordMsg(null)
+        if (newPassword !== confirmPassword) {
+            setPasswordMsg({ type: 'error', text: '新しいパスワードが一致しません' })
+            return
+        }
+        setPasswordLoading(true)
+        try {
+            await changePassword({ currentPassword, newPassword })
+            setPasswordMsg({ type: 'success', text: 'パスワードを変更しました' })
+            setCurrentPassword('')
+            setNewPassword('')
+            setConfirmPassword('')
+        } catch (err) {
+            setPasswordMsg({ type: 'error', text: err.response?.data?.message || 'パスワード変更に失敗しました' })
+        } finally {
+            setPasswordLoading(false)
+        }
+    }
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-box account-settings-modal" onClick={e => e.stopPropagation()}>
+                <div className="settings-modal-header">
+                    <h2 className="settings-modal-title">アカウント設定</h2>
+                    <button className="settings-modal-close" onClick={onClose}>✕</button>
+                </div>
+
+                <div className="settings-tabs">
+                    <button
+                        className={`settings-tab${tab === 'profile' ? ' active' : ''}`}
+                        onClick={() => setTab('profile')}
+                    >
+                        プロフィール
+                    </button>
+                    <button
+                        className={`settings-tab${tab === 'password' ? ' active' : ''}`}
+                        onClick={() => setTab('password')}
+                    >
+                        パスワード変更
+                    </button>
+                </div>
+
+                {tab === 'profile' && (
+                    <form className="settings-form" onSubmit={handleProfileSave}>
+                        {profileMsg && (
+                            <p className={profileMsg.type === 'success' ? 'settings-success' : 'auth-error'}>
+                                {profileMsg.text}
+                            </p>
+                        )}
+                        <label className="settings-label">ユーザー名 <span className="settings-hint">（英数字・_、3〜50文字）</span></label>
+                        <input
+                            className="auth-input"
+                            type="text"
+                            value={username}
+                            onChange={e => setUsername(e.target.value)}
+                            required
+                            minLength={3}
+                            maxLength={50}
+                            pattern="[a-zA-Z0-9_]+"
+                            autoComplete="username"
+                        />
+                        <label className="settings-label">メールアドレス</label>
+                        <input
+                            className="auth-input"
+                            type="email"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                            required
+                            autoComplete="email"
+                        />
+                        <button className="auth-btn-primary" type="submit" disabled={profileLoading}>
+                            {profileLoading ? '更新中...' : '変更を保存'}
+                        </button>
+                    </form>
+                )}
+
+                {tab === 'password' && (
+                    <form className="settings-form" onSubmit={handlePasswordSave}>
+                        {passwordMsg && (
+                            <p className={passwordMsg.type === 'success' ? 'settings-success' : 'auth-error'}>
+                                {passwordMsg.text}
+                            </p>
+                        )}
+                        <label className="settings-label">現在のパスワード</label>
+                        <input
+                            className="auth-input"
+                            type="password"
+                            value={currentPassword}
+                            onChange={e => setCurrentPassword(e.target.value)}
+                            required
+                            autoComplete="current-password"
+                        />
+                        <label className="settings-label">新しいパスワード（8文字以上）</label>
+                        <input
+                            className="auth-input"
+                            type="password"
+                            value={newPassword}
+                            onChange={e => setNewPassword(e.target.value)}
+                            required
+                            autoComplete="new-password"
+                        />
+                        <label className="settings-label">新しいパスワード（確認）</label>
+                        <input
+                            className="auth-input"
+                            type="password"
+                            value={confirmPassword}
+                            onChange={e => setConfirmPassword(e.target.value)}
+                            required
+                            autoComplete="new-password"
+                        />
+                        <button className="auth-btn-primary" type="submit" disabled={passwordLoading}>
+                            {passwordLoading ? '変更中...' : 'パスワードを変更'}
+                        </button>
+                    </form>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -99,3 +99,130 @@
 .auth-link a:hover {
     text-decoration: underline;
 }
+
+/* Header buttons */
+.header-user-btn {
+    background: rgba(255,255,255,0.15);
+    border: 1px solid rgba(255,255,255,0.4);
+    color: #fff;
+    padding: 6px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: background 0.15s;
+}
+.header-user-btn:hover {
+    background: rgba(255,255,255,0.25);
+}
+
+.header-ghost-btn {
+    background: rgba(255,255,255,0.1);
+    border: none;
+    color: #fff;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.15s;
+}
+.header-ghost-btn:hover {
+    background: rgba(255,255,255,0.2);
+}
+
+/* Account settings modal */
+.modal-box {
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.account-settings-modal {
+    width: 460px;
+    max-width: 95vw;
+}
+
+.settings-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid #eee;
+}
+
+.settings-modal-title {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #1a1a2e;
+}
+
+.settings-modal-close {
+    background: none;
+    border: none;
+    font-size: 1.1rem;
+    color: #888;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    line-height: 1;
+}
+.settings-modal-close:hover {
+    background: #f0f0f0;
+    color: #333;
+}
+
+.settings-tabs {
+    display: flex;
+    border-bottom: 1px solid #eee;
+    padding: 0 24px;
+    gap: 0;
+}
+
+.settings-tab {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    color: #666;
+    cursor: pointer;
+    margin-bottom: -1px;
+    transition: color 0.15s, border-color 0.15s;
+}
+.settings-tab:hover {
+    color: #333;
+}
+.settings-tab.active {
+    color: #4a90d9;
+    border-bottom-color: #4a90d9;
+    font-weight: 500;
+}
+
+.settings-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 20px 24px 24px;
+}
+
+.settings-label {
+    font-size: 0.85rem;
+    color: #555;
+    font-weight: 500;
+    margin-bottom: -4px;
+}
+
+.settings-success {
+    color: #2e7d32;
+    font-size: 0.875rem;
+    margin: 0;
+    padding: 8px 12px;
+    background: #e8f5e9;
+    border-radius: 4px;
+}
+
+.settings-hint {
+    font-weight: normal;
+    color: #999;
+    font-size: 0.8rem;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,101 @@
 /* global reset — app styles are in App.css */
+
+.auth-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background: #f0f2f5;
+    font-family: sans-serif;
+}
+
+.auth-form {
+    background: white;
+    padding: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    width: 380px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.auth-title {
+    margin: 0 0 8px;
+    font-size: 1.5rem;
+    color: #1a1a2e;
+    text-align: center;
+}
+
+.auth-input {
+    padding: 10px 14px;
+    border: 1px solid #d0d5dd;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.auth-input:focus {
+    border-color: #4a90d9;
+}
+
+.auth-btn-primary {
+    padding: 10px;
+    background: #4a90d9;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.auth-btn-primary:hover:not(:disabled) {
+    background: #357abd;
+}
+
+.auth-btn-primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.auth-btn-secondary {
+    padding: 10px;
+    background: white;
+    color: #333;
+    border: 1px solid #d0d5dd;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.auth-btn-secondary:hover {
+    background: #f5f5f5;
+}
+
+.auth-error {
+    color: #d32f2f;
+    font-size: 0.875rem;
+    margin: 0;
+    padding: 8px 12px;
+    background: #fdecea;
+    border-radius: 4px;
+}
+
+.auth-link {
+    text-align: center;
+    font-size: 0.875rem;
+    color: #555;
+    margin: 0;
+}
+
+.auth-link a {
+    color: #4a90d9;
+    text-decoration: none;
+}
+
+.auth-link a:hover {
+    text-decoration: underline;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,27 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import { AuthProvider } from './auth/AuthContext'
+import ProtectedRoute from './auth/ProtectedRoute'
+import LoginPage from './pages/LoginPage'
+import RegisterPage from './pages/RegisterPage'
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+    <StrictMode>
+        <BrowserRouter>
+            <AuthProvider>
+                <Routes>
+                    <Route path="/login" element={<LoginPage />} />
+                    <Route path="/register" element={<RegisterPage />} />
+                    <Route path="/" element={
+                        <ProtectedRoute>
+                            <App />
+                        </ProtectedRoute>
+                    } />
+                </Routes>
+            </AuthProvider>
+        </BrowserRouter>
+    </StrictMode>
 )

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { loginApi } from '../api/client'
+import { useAuth } from '../auth/AuthContext'
+
+export default function LoginPage() {
+    const [identifier, setIdentifier] = useState('')
+    const [password, setPassword] = useState('')
+    const [error, setError] = useState('')
+    const [loading, setLoading] = useState(false)
+    const { login } = useAuth()
+    const navigate = useNavigate()
+
+    async function handleSubmit(e) {
+        e.preventDefault()
+        setError('')
+        setLoading(true)
+        try {
+            const data = await loginApi({ identifier, password })
+            login(data.token, { id: data.userId, username: data.username, email: data.email })
+            navigate('/')
+        } catch (err) {
+            setError(err.response?.data?.message || 'ログインに失敗しました')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    function handlePasskey() {
+        setError('パスキー認証は現在準備中です')
+    }
+
+    return (
+        <div className="auth-page">
+            <form className="auth-form" onSubmit={handleSubmit}>
+                <h1 className="auth-title">ログイン</h1>
+                {error && <p className="auth-error">{error}</p>}
+                <input
+                    className="auth-input"
+                    type="text"
+                    placeholder="ユーザー名またはメールアドレス"
+                    value={identifier}
+                    onChange={e => setIdentifier(e.target.value)}
+                    required
+                    autoComplete="username"
+                />
+                <input
+                    className="auth-input"
+                    type="password"
+                    placeholder="パスワード"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    required
+                    autoComplete="current-password"
+                />
+                <button className="auth-btn-primary" type="submit" disabled={loading}>
+                    {loading ? 'ログイン中...' : 'ログイン'}
+                </button>
+                <button className="auth-btn-secondary" type="button" onClick={handlePasskey}>
+                    🔑 パスキーでログイン
+                </button>
+                <p className="auth-link">
+                    アカウントをお持ちでない方は <Link to="/register">新規登録</Link>
+                </p>
+            </form>
+        </div>
+    )
+}

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { register } from '../api/client'
+import { useAuth } from '../auth/AuthContext'
+
+export default function RegisterPage() {
+    const [username, setUsername] = useState('')
+    const [email, setEmail] = useState('')
+    const [password, setPassword] = useState('')
+    const [error, setError] = useState('')
+    const [loading, setLoading] = useState(false)
+    const { login } = useAuth()
+    const navigate = useNavigate()
+
+    async function handleSubmit(e) {
+        e.preventDefault()
+        setError('')
+        setLoading(true)
+        try {
+            const data = await register({ username, email, password })
+            login(data.token, { id: data.userId, username: data.username, email: data.email })
+            navigate('/')
+        } catch (err) {
+            setError(err.response?.data?.message || '登録に失敗しました')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <div className="auth-page">
+            <form className="auth-form" onSubmit={handleSubmit}>
+                <h1 className="auth-title">新規登録</h1>
+                {error && <p className="auth-error">{error}</p>}
+                <input
+                    className="auth-input"
+                    type="text"
+                    placeholder="ユーザー名（英数字・アンダースコア、3〜50文字）"
+                    value={username}
+                    onChange={e => setUsername(e.target.value)}
+                    required
+                    autoComplete="username"
+                />
+                <input
+                    className="auth-input"
+                    type="email"
+                    placeholder="メールアドレス"
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    required
+                    autoComplete="email"
+                />
+                <input
+                    className="auth-input"
+                    type="password"
+                    placeholder="パスワード（8文字以上）"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    required
+                    minLength={8}
+                    autoComplete="new-password"
+                />
+                <button className="auth-btn-primary" type="submit" disabled={loading}>
+                    {loading ? '登録中...' : '登録する'}
+                </button>
+                <p className="auth-link">
+                    すでにアカウントをお持ちの方は <Link to="/login">ログイン</Link>
+                </p>
+            </form>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- Spring Security + JWT認証を導入し、全エンドポイントを保護
- ユーザー名またはメールアドレス（どちらか入力）でログイン可能
- 新規登録でDBにユーザーを保存し、登録時にデフォルトボード「マイボード」を自動作成
- パスキー（指紋認証）ボタンのUIスタブを追加（本実装は別イシュー）
- ボードをユーザーごとに分離（他ユーザーのボードは404）
- DBのIDはBIGSERIAL（自動インクリメント）＋UNIQUE制約で重複排除

## Changes
### Backend
- `SecurityConfig`: Spring Security + CORS設定（`CorsConfig.java`を置き換え）
- `JwtUtil` / `JwtAuthFilter`: JWT生成・検証・認証フィルター
- `User` / `PasskeyCredential`: Entityと`users`/`passkey_credentials`テーブル
- `AuthController` / `AuthService`: `POST /api/auth/register`, `POST /api/auth/login`
- `PasskeyController`: パスキー用501スタブエンドポイント
- `BoardController`: 認証ユーザーのボードのみ返すよう変更

### Frontend
- `react-router-dom` 導入、ルーティング追加
- `LoginPage` / `RegisterPage` 新規作成
- `AuthContext` / `ProtectedRoute`: JWT管理と保護ルート
- `api/client.js`: JWTインターセプター追加

## Test plan
- [ ] `docker compose up -d` でDB起動
- [ ] `./gradlew bootRun` でバックエンド起動
- [ ] `npm run dev` でフロントエンド起動
- [ ] `http://localhost:5173/register` で新規登録
- [ ] ユーザー名・メールアドレスそれぞれでログイン確認
- [ ] 重複ユーザー名/メールでエラーメッセージが出ることを確認
- [ ] パスキーボタンで「準備中」メッセージが出ることを確認
- [ ] tokenを削除して `/` にアクセス → `/login` にリダイレクト確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)