### PR TITLE
feat: アカウント設定機能を追加（プロフィール編集・パスワード変更）

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardController.java
@@ -21,7 +21,7 @@ public class BoardController {
     @GetMapping
     public List<Board> getMyBoards(Authentication auth) {
         Long userId = (Long) auth.getPrincipal();
-        return boardRepository.findByUserId(userId);
+        return boardRepository.findByUser_Id(userId);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/taskmanagement/controller/UserController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/UserController.java
@@ -1,0 +1,76 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.AuthResponse;
+import com.taskmanagement.dto.ChangePasswordRequest;
+import com.taskmanagement.dto.UpdateProfileRequest;
+import com.taskmanagement.model.User;
+import com.taskmanagement.repository.UserRepository;
+import com.taskmanagement.security.JwtUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserRepository userRepo;
+    private final BCryptPasswordEncoder encoder;
+    private final JwtUtil jwtUtil;
+
+    public UserController(UserRepository userRepo, BCryptPasswordEncoder encoder, JwtUtil jwtUtil) {
+        this.userRepo = userRepo;
+        this.encoder = encoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<AuthResponse> getMe(Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+        return ResponseEntity.ok(new AuthResponse(null, user.getId(), user.getUsername(), user.getEmail()));
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<AuthResponse> updateProfile(@RequestBody UpdateProfileRequest req, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+
+        if (req.getUsername() != null && !req.getUsername().isBlank()) {
+            if (!req.getUsername().matches("[a-zA-Z0-9_]{3,50}"))
+                throw new RuntimeException("ユーザー名は英数字・アンダースコアで3〜50文字にしてください");
+            if (!req.getUsername().equals(user.getUsername()) && userRepo.existsByUsername(req.getUsername()))
+                throw new RuntimeException("このユーザー名はすでに使用されています");
+            user.setUsername(req.getUsername());
+        }
+
+        if (req.getEmail() != null && !req.getEmail().isBlank()) {
+            if (!req.getEmail().equals(user.getEmail()) && userRepo.existsByEmail(req.getEmail()))
+                throw new RuntimeException("このメールアドレスはすでに登録されています");
+            user.setEmail(req.getEmail());
+        }
+
+        userRepo.save(user);
+        String token = jwtUtil.generateToken(user.getId(), user.getUsername());
+        return ResponseEntity.ok(new AuthResponse(token, user.getId(), user.getUsername(), user.getEmail()));
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> changePassword(@RequestBody ChangePasswordRequest req, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+
+        if (req.getCurrentPassword() == null || !encoder.matches(req.getCurrentPassword(), user.getPasswordHash()))
+            throw new RuntimeException("現在のパスワードが正しくありません");
+        if (req.getNewPassword() == null || req.getNewPassword().length() < 8)
+            throw new RuntimeException("新しいパスワードは8文字以上で入力してください");
+
+        user.setPasswordHash(encoder.encode(req.getNewPassword()));
+        userRepo.save(user);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/ChangePasswordRequest.java
@@ -1,0 +1,12 @@
+package com.taskmanagement.dto;
+
+public class ChangePasswordRequest {
+    private String currentPassword;
+    private String newPassword;
+
+    public String getCurrentPassword() { return currentPassword; }
+    public void setCurrentPassword(String currentPassword) { this.currentPassword = currentPassword; }
+
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/UpdateProfileRequest.java
@@ -1,0 +1,12 @@
+package com.taskmanagement.dto;
+
+public class UpdateProfileRequest {
+    private String username;
+    private String email;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+}

--- a/backend/src/main/java/com/taskmanagement/repository/BoardRepository.java
+++ b/backend/src/main/java/com/taskmanagement/repository/BoardRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    List<Board> findByUserId(Long userId);
+    List<Board> findByUser_Id(Long userId);
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { DragDropContext } from '@hello-pangea/dnd'
 import List from './components/List'
 import CardModal from './components/CardModal'
+import AccountSettingsModal from './components/AccountSettingsModal'
 import {
     getMyBoards, getBoard, createList, updateList, deleteList,
     createCard, updateCard, deleteCard, moveCard
@@ -12,6 +13,7 @@ import './App.css'
 export default function App() {
     const [board, setBoard] = useState(null)
     const [editingCard, setEditingCard] = useState(null)
+    const [showSettings, setShowSettings] = useState(false)
     const { auth, logout } = useAuth()
 
     const loadBoard = useCallback(() => {
@@ -100,11 +102,15 @@ export default function App() {
             <header id="app-header">
                 <h1 id="app-title">📋 タスク管理アプリ</h1>
                 <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-                    <span style={{ color: '#fff', fontSize: '0.9rem' }}>
-                        {auth?.user?.username}
-                    </span>
                     <button
-                        style={{ background: 'rgba(255,255,255,0.2)', border: 'none', color: '#fff', padding: '6px 12px', borderRadius: 6, cursor: 'pointer' }}
+                        className="header-user-btn"
+                        onClick={() => setShowSettings(true)}
+                        title="アカウント設定"
+                    >
+                        {auth?.user?.username}
+                    </button>
+                    <button
+                        className="header-ghost-btn"
                         onClick={logout}
                     >
                         ログアウト
@@ -135,6 +141,10 @@ export default function App() {
                     onSave={handleSaveCard}
                     onClose={() => setEditingCard(null)}
                 />
+            )}
+
+            {showSettings && (
+                <AccountSettingsModal onClose={() => setShowSettings(false)} />
             )}
         </>
     )

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -23,6 +23,10 @@ api.interceptors.response.use(
 export const register = (data) => api.post('/auth/register', data).then(r => r.data)
 export const loginApi = (data) => api.post('/auth/login', data).then(r => r.data)
 
+export const getMe = () => api.get('/user/me').then(r => r.data)
+export const updateProfile = (data) => api.put('/user/profile', data).then(r => r.data)
+export const changePassword = (data) => api.put('/user/password', data)
+
 export const getMyBoards = () => api.get('/boards').then(r => r.data)
 export const getBoard = (id) => api.get(`/boards/${id}`).then(r => r.data)
 

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -21,8 +21,14 @@ export function AuthProvider({ children }) {
         setAuth(null)
     }, [])
 
+    const updateUser = useCallback((token, user) => {
+        localStorage.setItem('token', token)
+        localStorage.setItem('user', JSON.stringify(user))
+        setAuth({ token, user })
+    }, [])
+
     return (
-        <AuthContext.Provider value={{ auth, login, logout }}>
+        <AuthContext.Provider value={{ auth, login, logout, updateUser }}>
             {children}
         </AuthContext.Provider>
     )

--- a/frontend/src/components/AccountSettingsModal.jsx
+++ b/frontend/src/components/AccountSettingsModal.jsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+import { updateProfile, changePassword } from '../api/client'
+import { useAuth } from '../auth/AuthContext'
+
+export default function AccountSettingsModal({ onClose }) {
+    const { auth, updateUser } = useAuth()
+    const [tab, setTab] = useState('profile')
+
+    const [username, setUsername] = useState(auth?.user?.username || '')
+    const [email, setEmail] = useState(auth?.user?.email || '')
+    const [profileMsg, setProfileMsg] = useState(null)
+    const [profileLoading, setProfileLoading] = useState(false)
+
+    const [currentPassword, setCurrentPassword] = useState('')
+    const [newPassword, setNewPassword] = useState('')
+    const [confirmPassword, setConfirmPassword] = useState('')
+    const [passwordMsg, setPasswordMsg] = useState(null)
+    const [passwordLoading, setPasswordLoading] = useState(false)
+
+    async function handleProfileSave(e) {
+        e.preventDefault()
+        setProfileMsg(null)
+        if (!username.match(/^[a-zA-Z0-9_]{3,50}$/)) {
+            setProfileMsg({ type: 'error', text: 'ユーザー名は英数字・アンダースコアで3〜50文字にしてください' })
+            return
+        }
+        setProfileLoading(true)
+        try {
+            const data = await updateProfile({ username, email })
+            updateUser(data.token, { id: data.userId, username: data.username, email: data.email })
+            setProfileMsg({ type: 'success', text: 'プロフィールを更新しました' })
+        } catch (err) {
+            setProfileMsg({ type: 'error', text: err.response?.data?.message || '更新に失敗しました' })
+        } finally {
+            setProfileLoading(false)
+        }
+    }
+
+    async function handlePasswordSave(e) {
+        e.preventDefault()
+        setPasswordMsg(null)
+        if (newPassword !== confirmPassword) {
+            setPasswordMsg({ type: 'error', text: '新しいパスワードが一致しません' })
+            return
+        }
+        setPasswordLoading(true)
+        try {
+            await changePassword({ currentPassword, newPassword })
+            setPasswordMsg({ type: 'success', text: 'パスワードを変更しました' })
+            setCurrentPassword('')
+            setNewPassword('')
+            setConfirmPassword('')
+        } catch (err) {
+            setPasswordMsg({ type: 'error', text: err.response?.data?.message || 'パスワード変更に失敗しました' })
+        } finally {
+            setPasswordLoading(false)
+        }
+    }
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-box account-settings-modal" onClick={e => e.stopPropagation()}>
+                <div className="settings-modal-header">
+                    <h2 className="settings-modal-title">アカウント設定</h2>
+                    <button className="settings-modal-close" onClick={onClose}>✕</button>
+                </div>
+
+                <div className="settings-tabs">
+                    <button
+                        className={`settings-tab${tab === 'profile' ? ' active' : ''}`}
+                        onClick={() => setTab('profile')}
+                    >
+                        プロフィール
+                    </button>
+                    <button
+                        className={`settings-tab${tab === 'password' ? ' active' : ''}`}
+                        onClick={() => setTab('password')}
+                    >
+                        パスワード変更
+                    </button>
+                </div>
+
+                {tab === 'profile' && (
+                    <form className="settings-form" onSubmit={handleProfileSave}>
+                        {profileMsg && (
+                            <p className={profileMsg.type === 'success' ? 'settings-success' : 'auth-error'}>
+                                {profileMsg.text}
+                            </p>
+                        )}
+                        <label className="settings-label">ユーザー名 <span className="settings-hint">（英数字・_、3〜50文字）</span></label>
+                        <input
+                            className="auth-input"
+                            type="text"
+                            value={username}
+                            onChange={e => setUsername(e.target.value)}
+                            required
+                            minLength={3}
+                            maxLength={50}
+                            pattern="[a-zA-Z0-9_]+"
+                            autoComplete="username"
+                        />
+                        <label className="settings-label">メールアドレス</label>
+                        <input
+                            className="auth-input"
+                            type="email"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                            required
+                            autoComplete="email"
+                        />
+                        <button className="auth-btn-primary" type="submit" disabled={profileLoading}>
+                            {profileLoading ? '更新中...' : '変更を保存'}
+                        </button>
+                    </form>
+                )}
+
+                {tab === 'password' && (
+                    <form className="settings-form" onSubmit={handlePasswordSave}>
+                        {passwordMsg && (
+                            <p className={passwordMsg.type === 'success' ? 'settings-success' : 'auth-error'}>
+                                {passwordMsg.text}
+                            </p>
+                        )}
+                        <label className="settings-label">現在のパスワード</label>
+                        <input
+                            className="auth-input"
+                            type="password"
+                            value={currentPassword}
+                            onChange={e => setCurrentPassword(e.target.value)}
+                            required
+                            autoComplete="current-password"
+                        />
+                        <label className="settings-label">新しいパスワード（8文字以上）</label>
+                        <input
+                            className="auth-input"
+                            type="password"
+                            value={newPassword}
+                            onChange={e => setNewPassword(e.target.value)}
+                            required
+                            autoComplete="new-password"
+                        />
+                        <label className="settings-label">新しいパスワード（確認）</label>
+                        <input
+                            className="auth-input"
+                            type="password"
+                            value={confirmPassword}
+                            onChange={e => setConfirmPassword(e.target.value)}
+                            required
+                            autoComplete="new-password"
+                        />
+                        <button className="auth-btn-primary" type="submit" disabled={passwordLoading}>
+                            {passwordLoading ? '変更中...' : 'パスワードを変更'}
+                        </button>
+                    </form>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -99,3 +99,130 @@
 .auth-link a:hover {
     text-decoration: underline;
 }
+
+/* Header buttons */
+.header-user-btn {
+    background: rgba(255,255,255,0.15);
+    border: 1px solid rgba(255,255,255,0.4);
+    color: #fff;
+    padding: 6px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: background 0.15s;
+}
+.header-user-btn:hover {
+    background: rgba(255,255,255,0.25);
+}
+
+.header-ghost-btn {
+    background: rgba(255,255,255,0.1);
+    border: none;
+    color: #fff;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.15s;
+}
+.header-ghost-btn:hover {
+    background: rgba(255,255,255,0.2);
+}
+
+/* Account settings modal */
+.modal-box {
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.account-settings-modal {
+    width: 460px;
+    max-width: 95vw;
+}
+
+.settings-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid #eee;
+}
+
+.settings-modal-title {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #1a1a2e;
+}
+
+.settings-modal-close {
+    background: none;
+    border: none;
+    font-size: 1.1rem;
+    color: #888;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    line-height: 1;
+}
+.settings-modal-close:hover {
+    background: #f0f0f0;
+    color: #333;
+}
+
+.settings-tabs {
+    display: flex;
+    border-bottom: 1px solid #eee;
+    padding: 0 24px;
+    gap: 0;
+}
+
+.settings-tab {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 12px 16px;
+    font-size: 0.9rem;
+    color: #666;
+    cursor: pointer;
+    margin-bottom: -1px;
+    transition: color 0.15s, border-color 0.15s;
+}
+.settings-tab:hover {
+    color: #333;
+}
+.settings-tab.active {
+    color: #4a90d9;
+    border-bottom-color: #4a90d9;
+    font-weight: 500;
+}
+
+.settings-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 20px 24px 24px;
+}
+
+.settings-label {
+    font-size: 0.85rem;
+    color: #555;
+    font-weight: 500;
+    margin-bottom: -4px;
+}
+
+.settings-success {
+    color: #2e7d32;
+    font-size: 0.875rem;
+    margin: 0;
+    padding: 8px 12px;
+    background: #e8f5e9;
+    border-radius: 4px;
+}
+
+.settings-hint {
+    font-weight: normal;
+    color: #999;
+    font-size: 0.8rem;
+}


### PR DESCRIPTION
## 概要
- ヘッダーのユーザー名をクリックするとアカウント設定モーダルが開く
- プロフィールタブ：ユーザー名・メールアドレスの変更
- パスワード変更タブ：現在のパスワード確認付きのパスワード変更
- クライアント側バリデーション（ユーザー名形式・パスワード一致確認）

## 変更内容
### バックエンド
- `GET /api/user/me` — ログイン中のユーザー情報取得
- `PUT /api/user/profile` — ユーザー名・メールアドレス更新（重複チェック付き）
- `PUT /api/user/password` — パスワード変更（現在のパスワード検証付き）

### フロントエンド
- `AccountSettingsModal.jsx` 新規追加
- `AuthContext` に `updateUser` 追加
- `api/client.js` に `getMe`・`updateProfile`・`changePassword` 追加

## テスト計画
- [x] ユーザー名を変更し、ヘッダーに反映されることを確認
- [x] メールアドレスを変更し、次回ログイン時に使用できることを確認
- [x] 正しいパスワードで変更できることを確認
- [x] 誤った現在のパスワードでエラーが出ることを確認
- [x] 3文字未満のユーザー名でバリデーションエラーが出ることを確認
- [x] パスワード不一致でエラーが出ることを確認

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)