### PR TITLE
feat: ユーザー名に日本語（ひらがな・カタカナ・漢字）を許可

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/UserController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/UserController.java
@@ -40,8 +40,8 @@ public class UserController {
                 .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
 
         if (req.getUsername() != null && !req.getUsername().isBlank()) {
-            if (!req.getUsername().matches("[a-zA-Z0-9_]{3,50}"))
-                throw new RuntimeException("ユーザー名は英数字・アンダースコアで3〜50文字にしてください");
+            if (!req.getUsername().matches("[a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{3,50}"))
+                throw new RuntimeException("ユーザー名は3〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
             if (!req.getUsername().equals(user.getUsername()) && userRepo.existsByUsername(req.getUsername()))
                 throw new RuntimeException("このユーザー名はすでに使用されています");
             user.setUsername(req.getUsername());

--- a/backend/src/main/java/com/taskmanagement/service/AuthService.java
+++ b/backend/src/main/java/com/taskmanagement/service/AuthService.java
@@ -38,8 +38,8 @@ public class AuthService {
             throw new RuntimeException("メールアドレスを入力してください");
         if (req.getPassword() == null || req.getPassword().length() < 8)
             throw new RuntimeException("パスワードは8文字以上で入力してください");
-        if (!req.getUsername().matches("[a-zA-Z0-9_]{3,50}"))
-            throw new RuntimeException("ユーザー名は英数字・アンダースコアで3〜50文字にしてください");
+        if (!req.getUsername().matches("[a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{3,50}"))
+            throw new RuntimeException("ユーザー名は3〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
 
         if (userRepo.existsByUsername(req.getUsername()))
             throw new RuntimeException("このユーザー名はすでに使用されています");

--- a/frontend/src/components/AccountSettingsModal.jsx
+++ b/frontend/src/components/AccountSettingsModal.jsx
@@ -20,8 +20,8 @@ export default function AccountSettingsModal({ onClose }) {
     async function handleProfileSave(e) {
         e.preventDefault()
         setProfileMsg(null)
-        if (!username.match(/^[a-zA-Z0-9_]{3,50}$/)) {
-            setProfileMsg({ type: 'error', text: 'ユーザー名は英数字・アンダースコアで3〜50文字にしてください' })
+        if (!username.match(/^[a-zA-Z0-9_぀-ゟ゠-ヿ一-鿿㐀-䶿]{3,50}$/)) {
+            setProfileMsg({ type: 'error', text: 'ユーザー名は3〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）' })
             return
         }
         setProfileLoading(true)
@@ -87,7 +87,7 @@ export default function AccountSettingsModal({ onClose }) {
                                 {profileMsg.text}
                             </p>
                         )}
-                        <label className="settings-label">ユーザー名 <span className="settings-hint">（英数字・_、3〜50文字）</span></label>
+                        <label className="settings-label">ユーザー名 <span className="settings-hint">（3〜50文字・日本語も使用可）</span></label>
                         <input
                             className="auth-input"
                             type="text"
@@ -96,7 +96,6 @@ export default function AccountSettingsModal({ onClose }) {
                             required
                             minLength={3}
                             maxLength={50}
-                            pattern="[a-zA-Z0-9_]+"
                             autoComplete="username"
                         />
                         <label className="settings-label">メールアドレス</label>

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -40,7 +40,7 @@ export default function RegisterPage() {
                 <input
                     className="auth-input"
                     type="text"
-                    placeholder="ユーザー名（英数字・アンダースコア、3〜50文字）"
+                    placeholder="ユーザー名（3〜50文字・日本語も使用可）"
                     value={username}
                     onChange={e => setUsername(e.target.value)}
                     required


### PR DESCRIPTION
## 概要

ユーザー名でひらがな・カタカナ・漢字が使えるようにバリデーションを変更。

## 変更内容

| ファイル | 変更 |
|---|---|
| `AuthService.java` | ユーザー名の正規表現に日本語文字範囲を追加 |
| `UserController.java` | 同上（プロフィール更新エンドポイント） |
| `AccountSettingsModal.jsx` | フロントバリデーション正規表現・`pattern`属性削除・ラベル更新 |
| `RegisterPage.jsx` | プレースホルダーテキスト更新 |

## 許可する文字

- 英数字・アンダースコア（従来通り）
- ひらがな（U+3040–U+309F）
- カタカナ（U+30A0–U+30FF）
- 漢字 CJK統合漢字（U+4E00–U+9FFF）
- 漢字 CJK拡張A（U+3400–U+4DBF）
- 文字数制限: 3〜50文字（変更なし）

## テスト確認事項

- [ ] 新規登録でひらがな・カタカナ・漢字のユーザー名が登録できる
- [ ] アカウント設定でユーザー名を日本語に変更できる
- [ ] 2文字以下・51文字以上は弾かれる
- [ ] 許可外の文字（記号など）は弾かれる

Closes #27