### PR TITLE
fix: ListController/CardController に所有者チェックを追加

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/CardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/CardController.java
@@ -3,6 +3,7 @@ package com.taskmanagement.controller;
 import com.taskmanagement.model.Card;
 import com.taskmanagement.service.CardService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -29,26 +30,30 @@ public class CardController {
     }
 
     @PostMapping
-    public ResponseEntity<Card> create(@RequestBody Map<String, Object> body) {
+    public ResponseEntity<Card> create(@RequestBody Map<String, Object> body, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
         Long listId = Long.valueOf(body.get("listId").toString());
-        return ResponseEntity.ok(cardService.create(listId));
+        return ResponseEntity.ok(cardService.create(listId, userId));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Card> update(@PathVariable Long id, @RequestBody Map<String, Object> body) {
-        return ResponseEntity.ok(cardService.update(id, body));
+    public ResponseEntity<Card> update(@PathVariable Long id, @RequestBody Map<String, Object> body, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        return ResponseEntity.ok(cardService.update(id, body, userId));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        cardService.delete(id);
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        cardService.delete(id, userId);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/{id}/move")
-    public ResponseEntity<Card> move(@PathVariable Long id, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<Card> move(@PathVariable Long id, @RequestBody Map<String, Object> body, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
         Long toListId = Long.valueOf(body.get("toListId").toString());
         int newPosition = Integer.parseInt(body.get("position").toString());
-        return ResponseEntity.ok(cardService.move(id, toListId, newPosition));
+        return ResponseEntity.ok(cardService.move(id, toListId, newPosition, userId));
     }
 }

--- a/backend/src/main/java/com/taskmanagement/controller/ListController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/ListController.java
@@ -3,6 +3,7 @@ package com.taskmanagement.controller;
 import com.taskmanagement.model.TaskList;
 import com.taskmanagement.service.ListService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,27 +20,31 @@ public class ListController {
     }
 
     @PostMapping
-    public ResponseEntity<TaskList> create(@RequestBody Map<String, Object> body) {
+    public ResponseEntity<TaskList> create(@RequestBody Map<String, Object> body, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
         Long boardId = Long.valueOf(body.get("boardId").toString());
         String title = (String) body.getOrDefault("title", "新しいリスト");
-        return ResponseEntity.ok(listService.create(boardId, title));
+        return ResponseEntity.ok(listService.create(boardId, title, userId));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<TaskList> update(@PathVariable Long id, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<TaskList> update(@PathVariable Long id, @RequestBody Map<String, Object> body, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
         String title = (String) body.get("title");
-        return ResponseEntity.ok(listService.updateTitle(id, title));
+        return ResponseEntity.ok(listService.updateTitle(id, title, userId));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        listService.delete(id);
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        listService.delete(id, userId);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/reorder")
-    public ResponseEntity<Void> reorder(@RequestBody List<Map<String, Object>> items) {
-        listService.reorder(items);
+    public ResponseEntity<Void> reorder(@RequestBody List<Map<String, Object>> items, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        listService.reorder(items, userId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/taskmanagement/repository/CardRepository.java
+++ b/backend/src/main/java/com/taskmanagement/repository/CardRepository.java
@@ -3,7 +3,9 @@ package com.taskmanagement.repository;
 import com.taskmanagement.model.Card;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
     List<Card> findByListIdOrderByPosition(Long listId);
+    Optional<Card> findByIdAndList_Board_User_Id(Long id, Long userId);
 }

--- a/backend/src/main/java/com/taskmanagement/repository/TaskListRepository.java
+++ b/backend/src/main/java/com/taskmanagement/repository/TaskListRepository.java
@@ -3,7 +3,9 @@ package com.taskmanagement.repository;
 import com.taskmanagement.model.TaskList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface TaskListRepository extends JpaRepository<TaskList, Long> {
     List<TaskList> findByBoardIdOrderByPosition(Long boardId);
+    Optional<TaskList> findByIdAndBoard_User_Id(Long id, Long userId);
 }

--- a/backend/src/main/java/com/taskmanagement/service/CardService.java
+++ b/backend/src/main/java/com/taskmanagement/service/CardService.java
@@ -37,8 +37,8 @@ public class CardService {
         return cardRepository.findByListIdOrderByPosition(listId);
     }
 
-    public Card create(Long listId) {
-        TaskList list = listRepository.findById(listId)
+    public Card create(Long listId, Long userId) {
+        TaskList list = listRepository.findByIdAndBoard_User_Id(listId, userId)
                 .orElseThrow(() -> new RuntimeException("List not found: " + listId));
         int position = cardRepository.findByListIdOrderByPosition(listId).size();
         Card card = new Card();
@@ -48,8 +48,8 @@ public class CardService {
         return cardRepository.save(card);
     }
 
-    public Card update(Long id, Map<String, Object> body) {
-        Card card = cardRepository.findById(id)
+    public Card update(Long id, Map<String, Object> body, Long userId) {
+        Card card = cardRepository.findByIdAndList_Board_User_Id(id, userId)
                 .orElseThrow(() -> new RuntimeException("Card not found: " + id));
 
         if (body.containsKey("title")) {
@@ -74,19 +74,20 @@ public class CardService {
         return cardRepository.save(card);
     }
 
-    public void delete(Long id) {
-        cardRepository.deleteById(id);
+    public void delete(Long id, Long userId) {
+        Card card = cardRepository.findByIdAndList_Board_User_Id(id, userId)
+                .orElseThrow(() -> new RuntimeException("Card not found: " + id));
+        cardRepository.delete(card);
     }
 
-    public Card move(Long cardId, Long toListId, int newPosition) {
-        Card card = cardRepository.findById(cardId)
+    public Card move(Long cardId, Long toListId, int newPosition, Long userId) {
+        Card card = cardRepository.findByIdAndList_Board_User_Id(cardId, userId)
                 .orElseThrow(() -> new RuntimeException("Card not found: " + cardId));
-        TaskList toList = listRepository.findById(toListId)
+        TaskList toList = listRepository.findByIdAndBoard_User_Id(toListId, userId)
                 .orElseThrow(() -> new RuntimeException("List not found: " + toListId));
 
         Long fromListId = card.getList().getId();
 
-        // Remove from source list and reindex
         if (!fromListId.equals(toListId)) {
             List<Card> fromCards = cardRepository.findByListIdOrderByPosition(fromListId);
             fromCards.remove(card);
@@ -96,9 +97,8 @@ public class CardService {
             }
         }
 
-        // Insert into destination list
         List<Card> toCards = cardRepository.findByListIdOrderByPosition(toListId);
-        toCards.remove(card); // in case same list
+        toCards.remove(card);
         toCards.add(Math.min(newPosition, toCards.size()), card);
         for (int i = 0; i < toCards.size(); i++) {
             toCards.get(i).setPosition(i);

--- a/backend/src/main/java/com/taskmanagement/service/ListService.java
+++ b/backend/src/main/java/com/taskmanagement/service/ListService.java
@@ -22,8 +22,9 @@ public class ListService {
         this.boardRepository = boardRepository;
     }
 
-    public TaskList create(Long boardId, String title) {
+    public TaskList create(Long boardId, String title, Long userId) {
         Board board = boardRepository.findById(boardId)
+                .filter(b -> b.getUser() != null && b.getUser().getId().equals(userId))
                 .orElseThrow(() -> new RuntimeException("Board not found: " + boardId));
         int position = listRepository.findByBoardIdOrderByPosition(boardId).size();
         TaskList list = new TaskList();
@@ -33,22 +34,24 @@ public class ListService {
         return listRepository.save(list);
     }
 
-    public TaskList updateTitle(Long id, String title) {
-        TaskList list = listRepository.findById(id)
+    public TaskList updateTitle(Long id, String title, Long userId) {
+        TaskList list = listRepository.findByIdAndBoard_User_Id(id, userId)
                 .orElseThrow(() -> new RuntimeException("List not found: " + id));
         list.setTitle(title);
         return listRepository.save(list);
     }
 
-    public void delete(Long id) {
-        listRepository.deleteById(id);
+    public void delete(Long id, Long userId) {
+        TaskList list = listRepository.findByIdAndBoard_User_Id(id, userId)
+                .orElseThrow(() -> new RuntimeException("List not found: " + id));
+        listRepository.delete(list);
     }
 
-    public void reorder(List<Map<String, Object>> items) {
+    public void reorder(List<Map<String, Object>> items, Long userId) {
         for (Map<String, Object> item : items) {
             Long id = Long.valueOf(item.get("id").toString());
             Integer position = Integer.valueOf(item.get("position").toString());
-            listRepository.findById(id).ifPresent(list -> {
+            listRepository.findByIdAndBoard_User_Id(id, userId).ifPresent(list -> {
                 list.setPosition(position);
                 listRepository.save(list);
             });


### PR DESCRIPTION
## 概要

認証済みユーザーが他ユーザーのリスト・カードを操作できるセキュリティ脆弱性を修正。

## 問題

`ListController` / `CardController` には認可チェックがなく、`BoardController` の所有者チェックが下位リソースに適用されていなかった。

## 変更内容

- `TaskListRepository` に `findByIdAndBoard_User_Id` を追加
- `CardRepository` に `findByIdAndList_Board_User_Id` を追加
- `ListService` の全メソッドに `userId` を追加し所有者検証を実施
- `CardService` の全メソッドに `userId` を追加し所有者検証を実施
- `ListController` / `CardController` で `Authentication` から `userId` を取得して渡す

## テスト計画

- [x] 自分のリスト・カードは正常に操作できること
- [ ] 他ユーザーのリスト・カードへの操作が 400 エラーになること

Closes #31