### PR TITLE
fix: ログイン画面のパスキーボタンを削除

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -26,10 +26,6 @@ export default function LoginPage() {
         }
     }
 
-    function handlePasskey() {
-        setError('パスキー認証は現在準備中です')
-    }
-
     return (
         <div className="auth-page">
             <form className="auth-form" onSubmit={handleSubmit}>
@@ -55,9 +51,6 @@ export default function LoginPage() {
                 />
                 <button className="auth-btn-primary" type="submit" disabled={loading}>
                     {loading ? 'ログイン中...' : 'ログイン'}
-                </button>
-                <button className="auth-btn-secondary" type="button" onClick={handlePasskey}>
-                    🔑 パスキーでログイン
                 </button>
                 <p className="auth-link">
                     アカウントをお持ちでない方は <Link to="/register">新規登録</Link>


### PR DESCRIPTION
## 概要

未実装のパスキー認証ボタンを削除。

## 変更内容

- `handlePasskey` 関数を削除
- 「🔑 パスキーでログイン」ボタンを削除

Closes #38