### PR TITLE
fix: D&D削除ゾーンを削除

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { DragDropContext, Droppable } from '@hello-pangea/dnd'
+import { DragDropContext } from '@hello-pangea/dnd'
 import List from './components/List'
 import CardModal from './components/CardModal'
 import AccountSettingsModal from './components/AccountSettingsModal'
@@ -14,7 +14,6 @@ export default function App() {
     const [board, setBoard] = useState(null)
     const [editingCard, setEditingCard] = useState(null)
     const [showSettings, setShowSettings] = useState(false)
-    const [isDragging, setIsDragging] = useState(false)
     const { auth, logout } = useAuth()
 
     const loadBoard = useCallback(() => {
@@ -77,21 +76,11 @@ export default function App() {
         setEditingCard(null)
     }
 
-    function handleDragStart() {
-        setIsDragging(true)
-    }
-
     async function handleDragEnd(result) {
-        setIsDragging(false)
         const { source, destination, draggableId } = result
         if (!destination) return
 
         const cardId = parseInt(draggableId)
-
-        if (destination.droppableId === 'trash') {
-            await handleDeleteCard(cardId)
-            return
-        }
 
         if (source.droppableId === destination.droppableId && source.index === destination.index) return
 
@@ -128,7 +117,7 @@ export default function App() {
                 </div>
             </header>
 
-            <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+            <DragDropContext onDragEnd={handleDragEnd}>
                 <main id="board">
                     {board.lists.map(list => (
                         <List
@@ -143,19 +132,6 @@ export default function App() {
                     ))}
                 </main>
 
-                <Droppable droppableId="trash">
-                    {(provided, snapshot) => (
-                        <div
-                            ref={provided.innerRef}
-                            {...provided.droppableProps}
-                            className={`trash-zone${isDragging ? ' visible' : ''}${snapshot.isDraggingOver ? ' over' : ''}`}
-                        >
-                            🗑
-                            <span>{snapshot.isDraggingOver ? 'ここで離すと削除' : 'ここにドラッグして削除'}</span>
-                            {provided.placeholder}
-                        </div>
-                    )}
-                </Droppable>
             </DragDropContext>
 
             {editingCard && (


### PR DESCRIPTION
## 概要
「ここにドラッグして削除」ゾーンを削除。

## 理由
- カードにはすでに削除ボタン（×ボタン）が存在する
- D&D削除ゾーンはカードのみ対応でリストは削除できず、機能に一貫性がない
- UI上の冗長な要素を取り除くことでシンプル化

## 変更内容
- `Droppable` (trash-zone) を削除
- `isDragging` state を削除
- `handleDragStart` 関数を削除
- `onDragStart` prop を削除
- `destination.droppableId === 'trash'` の分岐を削除

Closes #40