### PR TITLE
fix: ログイン・登録画面で日本語ユーザー名を正しく扱う

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/UserController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/UserController.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import java.text.Normalizer;
+
 @RestController
 @RequestMapping("/api/user")
 public class UserController {
@@ -40,11 +42,12 @@ public class UserController {
                 .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
 
         if (req.getUsername() != null && !req.getUsername().isBlank()) {
-            if (!req.getUsername().matches("[a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{3,50}"))
-                throw new RuntimeException("ユーザー名は3〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
-            if (!req.getUsername().equals(user.getUsername()) && userRepo.existsByUsername(req.getUsername()))
+            String username = Normalizer.normalize(req.getUsername().trim(), Normalizer.Form.NFC);
+            if (!username.matches("[a-zA-Z0-9_\\u3005\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{2,50}"))
+                throw new RuntimeException("ユーザー名は2〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
+            if (!username.equals(user.getUsername()) && userRepo.existsByUsername(username))
                 throw new RuntimeException("このユーザー名はすでに使用されています");
-            user.setUsername(req.getUsername());
+            user.setUsername(username);
         }
 
         if (req.getEmail() != null && !req.getEmail().isBlank()) {

--- a/backend/src/main/java/com/taskmanagement/service/AuthService.java
+++ b/backend/src/main/java/com/taskmanagement/service/AuthService.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.Normalizer;
 import java.util.Optional;
 
 @Service
@@ -38,16 +39,18 @@ public class AuthService {
             throw new RuntimeException("メールアドレスを入力してください");
         if (req.getPassword() == null || req.getPassword().length() < 8)
             throw new RuntimeException("パスワードは8文字以上で入力してください");
-        if (!req.getUsername().matches("[a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{3,50}"))
-            throw new RuntimeException("ユーザー名は3〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
 
-        if (userRepo.existsByUsername(req.getUsername()))
+        String username = Normalizer.normalize(req.getUsername().trim(), Normalizer.Form.NFC);
+        if (!username.matches("[a-zA-Z0-9_\\u3005\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{2,50}"))
+            throw new RuntimeException("ユーザー名は2〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
+
+        if (userRepo.existsByUsername(username))
             throw new RuntimeException("このユーザー名はすでに使用されています");
         if (userRepo.existsByEmail(req.getEmail()))
             throw new RuntimeException("このメールアドレスはすでに登録されています");
 
         User user = new User();
-        user.setUsername(req.getUsername());
+        user.setUsername(username);
         user.setEmail(req.getEmail());
         user.setPasswordHash(encoder.encode(req.getPassword()));
         userRepo.save(user);
@@ -65,9 +68,10 @@ public class AuthService {
         if (req.getIdentifier() == null || req.getIdentifier().isBlank())
             throw new RuntimeException("ユーザー名またはメールアドレスを入力してください");
 
-        Optional<User> userOpt = req.getIdentifier().contains("@")
-                ? userRepo.findByEmail(req.getIdentifier())
-                : userRepo.findByUsername(req.getIdentifier());
+        String identifier = Normalizer.normalize(req.getIdentifier().trim(), Normalizer.Form.NFC);
+        Optional<User> userOpt = identifier.contains("@")
+                ? userRepo.findByEmail(identifier)
+                : userRepo.findByUsername(identifier);
 
         User user = userOpt.orElseThrow(() -> new RuntimeException("ユーザー名またはパスワードが正しくありません"));
 

--- a/frontend/src/components/AccountSettingsModal.jsx
+++ b/frontend/src/components/AccountSettingsModal.jsx
@@ -21,8 +21,8 @@ export default function AccountSettingsModal({ onClose }) {
     async function handleProfileSave(e) {
         e.preventDefault()
         setProfileMsg(null)
-        if (!username.match(/^[a-zA-Z0-9_぀-ゟ゠-ヿ一-鿿㐀-䶿]{3,50}$/)) {
-            setProfileMsg({ type: 'error', text: 'ユーザー名は3〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）' })
+        if (!username.match(/^[a-zA-Z0-9_々぀-ゟ゠-ヿ一-鿿㐀-䶿]{2,50}$/u)) {
+            setProfileMsg({ type: 'error', text: 'ユーザー名は2〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）' })
             return
         }
         setProfileLoading(true)
@@ -88,14 +88,14 @@ export default function AccountSettingsModal({ onClose }) {
                                 {profileMsg.text}
                             </p>
                         )}
-                        <label className="settings-label">ユーザー名 <span className="settings-hint">（3〜50文字・日本語も使用可）</span></label>
+                        <label className="settings-label">ユーザー名 <span className="settings-hint">（2〜50文字・日本語も使用可）</span></label>
                         <input
                             className="auth-input"
                             type="text"
                             value={username}
                             onChange={e => setUsername(e.target.value)}
                             required
-                            minLength={3}
+                            minLength={2}
                             maxLength={50}
                             autoComplete="username"
                         />

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -41,7 +41,7 @@ export default function RegisterPage() {
                 <input
                     className="auth-input"
                     type="text"
-                    placeholder="ユーザー名（3〜50文字・日本語も使用可）"
+                    placeholder="ユーザー名（2〜50文字・日本語も使用可）"
                     value={username}
                     onChange={e => setUsername(e.target.value)}
                     required


### PR DESCRIPTION
## Summary

- **NFC正規化を追加**: macOSのJapanese IMEがNFD形式で文字を出力するケースがあり、登録時と異なる正規化形式でログインすると `findByUsername` がマッチしなかった。`AuthService.register()` と `AuthService.login()` の両方でNFC正規化を実施するよう修正。
- **正規表現を拡張**: `々`（U+3005、繰り返し文字）を許可リストに追加。
- **最小文字数を2に変更**: 日本語では「山田」「田中」のような2文字の名前が一般的なため、最小文字数を3→2に変更。
- **UserController.updateProfile も同様に更新**: プロフィール編集でも同じ正規化・バリデーションを適用。
- **フロントエンド**: `AccountSettingsModal` のクライアント側バリデーションと `RegisterPage` のプレースホルダーをバックエンドに合わせて更新。

## Test plan

- [ ] 日本語ユーザー名（ひらがな、カタカナ、漢字）で新規登録できる
- [ ] 登録した日本語ユーザー名でログインできる
- [ ] 2文字の日本語名（例: 田中）でも登録・ログインできる
- [ ] `々` を含む名前（例: 佐々木）で登録・ログインできる
- [ ] アカウント設定から日本語ユーザー名に変更できる
- [ ] 英数字のユーザー名は引き続き動作する

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)