### PR TITLE
fix: テストのコンパイルエラー修正・BoardController所有者バグ・カード取得の権限チェック追加

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardController.java
@@ -1,7 +1,9 @@
 package com.taskmanagement.controller;
 
 import com.taskmanagement.model.Board;
+import com.taskmanagement.model.User;
 import com.taskmanagement.repository.BoardRepository;
+import com.taskmanagement.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -13,9 +15,11 @@ import java.util.List;
 public class BoardController {
 
     private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
 
-    public BoardController(BoardRepository boardRepository) {
+    public BoardController(BoardRepository boardRepository, UserRepository userRepository) {
         this.boardRepository = boardRepository;
+        this.userRepository = userRepository;
     }
 
     @GetMapping
@@ -34,8 +38,12 @@ public class BoardController {
     }
 
     @PostMapping
-    public Board createBoard(@RequestBody Board board) {
-        return boardRepository.save(board);
+    public ResponseEntity<Board> createBoard(@RequestBody Board board, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        board.setUser(user);
+        return ResponseEntity.ok(boardRepository.save(board));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/taskmanagement/controller/CardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/CardController.java
@@ -20,13 +20,15 @@ public class CardController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Card> getById(@PathVariable Long id) {
-        return ResponseEntity.ok(cardService.findById(id));
+    public ResponseEntity<Card> getById(@PathVariable Long id, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        return ResponseEntity.ok(cardService.findByIdAndUserId(id, userId));
     }
 
     @GetMapping
-    public ResponseEntity<List<Card>> getByListId(@RequestParam Long listId) {
-        return ResponseEntity.ok(cardService.findByListId(listId));
+    public ResponseEntity<List<Card>> getByListId(@RequestParam Long listId, Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        return ResponseEntity.ok(cardService.findByListId(listId, userId));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/taskmanagement/service/CardService.java
+++ b/backend/src/main/java/com/taskmanagement/service/CardService.java
@@ -24,16 +24,15 @@ public class CardService {
     }
 
     @Transactional(readOnly = true)
-    public Card findById(Long id) {
-        return cardRepository.findById(id)
+    public Card findByIdAndUserId(Long id, Long userId) {
+        return cardRepository.findByIdAndList_Board_User_Id(id, userId)
                 .orElseThrow(() -> new RuntimeException("Card not found: " + id));
     }
 
     @Transactional(readOnly = true)
-    public List<Card> findByListId(Long listId) {
-        if (!listRepository.existsById(listId)) {
-            throw new RuntimeException("List not found: " + listId);
-        }
+    public List<Card> findByListId(Long listId, Long userId) {
+        listRepository.findByIdAndBoard_User_Id(listId, userId)
+                .orElseThrow(() -> new RuntimeException("List not found: " + listId));
         return cardRepository.findByListIdOrderByPosition(listId);
     }
 

--- a/backend/src/test/java/com/taskmanagement/service/CardServiceTest.java
+++ b/backend/src/test/java/com/taskmanagement/service/CardServiceTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CardServiceTest {
 
+    static final Long USER_ID = 99L;
+
     @Mock
     CardRepository cardRepository;
 
@@ -57,10 +59,10 @@ class CardServiceTest {
     void update_setDueDate_storesLocalDate() {
         TaskList list = makeList(1L);
         Card card = makeCard(1L, 0, list);
-        when(cardRepository.findById(1L)).thenReturn(Optional.of(card));
+        when(cardRepository.findByIdAndList_Board_User_Id(1L, USER_ID)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        Card result = cardService.update(1L, Map.of("dueDate", "2025-12-31"));
+        Card result = cardService.update(1L, Map.of("dueDate", "2025-12-31"), USER_ID);
 
         assertThat(result.getDueDate()).isEqualTo(LocalDate.of(2025, 12, 31));
     }
@@ -70,10 +72,10 @@ class CardServiceTest {
         TaskList list = makeList(1L);
         Card card = makeCard(1L, 0, list);
         card.setDueDate(LocalDate.of(2025, 1, 1));
-        when(cardRepository.findById(1L)).thenReturn(Optional.of(card));
+        when(cardRepository.findByIdAndList_Board_User_Id(1L, USER_ID)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        Card result = cardService.update(1L, Map.of("dueDate", ""));
+        Card result = cardService.update(1L, Map.of("dueDate", ""), USER_ID);
 
         assertThat(result.getDueDate()).isNull();
     }
@@ -82,10 +84,10 @@ class CardServiceTest {
     void update_setPriority_storesPriority() {
         TaskList list = makeList(1L);
         Card card = makeCard(1L, 0, list);
-        when(cardRepository.findById(1L)).thenReturn(Optional.of(card));
+        when(cardRepository.findByIdAndList_Board_User_Id(1L, USER_ID)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        Card result = cardService.update(1L, Map.of("priority", "high"));
+        Card result = cardService.update(1L, Map.of("priority", "high"), USER_ID);
 
         assertThat(result.getPriority()).isEqualTo("high");
     }
@@ -95,10 +97,10 @@ class CardServiceTest {
         TaskList list = makeList(1L);
         Card card = makeCard(1L, 0, list);
         card.setPriority("high");
-        when(cardRepository.findById(1L)).thenReturn(Optional.of(card));
+        when(cardRepository.findByIdAndList_Board_User_Id(1L, USER_ID)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        Card result = cardService.update(1L, Map.of("priority", ""));
+        Card result = cardService.update(1L, Map.of("priority", ""), USER_ID);
 
         assertThat(result.getPriority()).isNull();
     }
@@ -107,10 +109,10 @@ class CardServiceTest {
     void update_blankTitle_fallsBackToDefault() {
         TaskList list = makeList(1L);
         Card card = makeCard(1L, 0, list);
-        when(cardRepository.findById(1L)).thenReturn(Optional.of(card));
+        when(cardRepository.findByIdAndList_Board_User_Id(1L, USER_ID)).thenReturn(Optional.of(card));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        Card result = cardService.update(1L, Map.of("title", "   "));
+        Card result = cardService.update(1L, Map.of("title", "   "), USER_ID);
 
         assertThat(result.getTitle()).isEqualTo("無題のカード");
     }
@@ -125,13 +127,13 @@ class CardServiceTest {
         Card b = makeCard(2L, 1, list);
         Card c = makeCard(3L, 2, list);
 
-        when(cardRepository.findById(1L)).thenReturn(Optional.of(a));
-        when(listRepository.findById(10L)).thenReturn(Optional.of(list));
+        when(cardRepository.findByIdAndList_Board_User_Id(1L, USER_ID)).thenReturn(Optional.of(a));
+        when(listRepository.findByIdAndBoard_User_Id(10L, USER_ID)).thenReturn(Optional.of(list));
         when(cardRepository.findByListIdOrderByPosition(10L))
                 .thenReturn(new ArrayList<>(List.of(a, b, c)));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        cardService.move(1L, 10L, 2);
+        cardService.move(1L, 10L, 2, USER_ID);
 
         assertThat(b.getPosition()).isEqualTo(0);
         assertThat(c.getPosition()).isEqualTo(1);
@@ -146,13 +148,13 @@ class CardServiceTest {
         Card b = makeCard(2L, 1, list);
         Card c = makeCard(3L, 2, list);
 
-        when(cardRepository.findById(3L)).thenReturn(Optional.of(c));
-        when(listRepository.findById(10L)).thenReturn(Optional.of(list));
+        when(cardRepository.findByIdAndList_Board_User_Id(3L, USER_ID)).thenReturn(Optional.of(c));
+        when(listRepository.findByIdAndBoard_User_Id(10L, USER_ID)).thenReturn(Optional.of(list));
         when(cardRepository.findByListIdOrderByPosition(10L))
                 .thenReturn(new ArrayList<>(List.of(a, b, c)));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        cardService.move(3L, 10L, 0);
+        cardService.move(3L, 10L, 0, USER_ID);
 
         assertThat(c.getPosition()).isEqualTo(0);
         assertThat(a.getPosition()).isEqualTo(1);
@@ -171,15 +173,15 @@ class CardServiceTest {
         Card d = makeCard(4L, 0, toList);
         Card e = makeCard(5L, 1, toList);
 
-        when(cardRepository.findById(2L)).thenReturn(Optional.of(b));
-        when(listRepository.findById(20L)).thenReturn(Optional.of(toList));
+        when(cardRepository.findByIdAndList_Board_User_Id(2L, USER_ID)).thenReturn(Optional.of(b));
+        when(listRepository.findByIdAndBoard_User_Id(20L, USER_ID)).thenReturn(Optional.of(toList));
         when(cardRepository.findByListIdOrderByPosition(10L))
                 .thenReturn(new ArrayList<>(List.of(a, b, c)));
         when(cardRepository.findByListIdOrderByPosition(20L))
                 .thenReturn(new ArrayList<>(List.of(d, e)));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        cardService.move(2L, 20L, 1);
+        cardService.move(2L, 20L, 1, USER_ID);
 
         assertThat(a.getPosition()).isEqualTo(0);
         assertThat(c.getPosition()).isEqualTo(1);
@@ -197,15 +199,15 @@ class CardServiceTest {
         Card d = makeCard(4L, 0, toList);
         Card e = makeCard(5L, 1, toList);
 
-        when(cardRepository.findById(2L)).thenReturn(Optional.of(b));
-        when(listRepository.findById(20L)).thenReturn(Optional.of(toList));
+        when(cardRepository.findByIdAndList_Board_User_Id(2L, USER_ID)).thenReturn(Optional.of(b));
+        when(listRepository.findByIdAndBoard_User_Id(20L, USER_ID)).thenReturn(Optional.of(toList));
         when(cardRepository.findByListIdOrderByPosition(10L))
                 .thenReturn(new ArrayList<>(List.of(a, b, c)));
         when(cardRepository.findByListIdOrderByPosition(20L))
                 .thenReturn(new ArrayList<>(List.of(d, e)));
         when(cardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
-        cardService.move(2L, 20L, 1);
+        cardService.move(2L, 20L, 1, USER_ID);
 
         assertThat(d.getPosition()).isEqualTo(0);
         assertThat(b.getPosition()).isEqualTo(1);


### PR DESCRIPTION
## 概要

静的分析で発見したCritical/Highレベルのバグを修正。

- テストが本番コードのシグネチャと一致せずコンパイルエラーになっていた
- ボード作成APIで所有者が設定されず、任意ユーザーへの権限昇格が可能だった
- カード取得APIが所有者チェックなしで誰でも他ユーザーのカードを参照できた

## 変更内容

### CardServiceTest（コンパイルエラー修正）
- `update()` 呼び出しを `update(id, body)` → `update(id, body, userId)` に修正
- `move()` 呼び出しを `move(cardId, toListId, pos)` → `move(cardId, toListId, pos, userId)` に修正
- モックを `findById` → `findByIdAndList_Board_User_Id` / `findByIdAndBoard_User_Id` に修正

### BoardController（権限昇格バグ修正）
- `createBoard()` に `Authentication auth` を追加し `board.setUser(user)` を設定

### CardService / CardController（所有者チェック追加）
- `findByIdAndUserId(id, userId)` を追加（`findByIdAndList_Board_User_Id` を使用）
- `findByListId(listId, userId)` を変更（リスト所有者検証を追加）
- `GET /api/cards/{id}` と `GET /api/cards?listId=X` に `userId` チェックを適用

Closes #44