### PR TITLE
fix: ユーザー名にスペース許可・パスワードプレースホルダー修正・必須バリデーション強化

### DIFF
--- a/backend/src/main/java/com/taskmanagement/service/AuthService.java
+++ b/backend/src/main/java/com/taskmanagement/service/AuthService.java
@@ -40,9 +40,11 @@ public class AuthService {
         if (req.getPassword() == null || req.getPassword().length() < 8)
             throw new RuntimeException("パスワードは8文字以上で入力してください");
 
-        String username = Normalizer.normalize(req.getUsername().trim(), Normalizer.Form.NFC);
-        if (!username.matches("[a-zA-Z0-9_\\u3005\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{2,50}"))
-            throw new RuntimeException("ユーザー名は2〜50文字で入力してください（英数字・アンダースコア・日本語が使えます）");
+        String username = Normalizer.normalize(req.getUsername().strip(), Normalizer.Form.NFC);
+        if (username.isBlank())
+            throw new RuntimeException("ユーザー名を入力してください");
+        if (!username.matches("[a-zA-Z0-9_ \\u3000\\u3005\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FFF\\u3400-\\u4DBF]{2,50}"))
+            throw new RuntimeException("ユーザー名は2〜50文字で入力してください（英数字・スペース・日本語が使えます）");
 
         if (userRepo.existsByUsername(username))
             throw new RuntimeException("このユーザー名はすでに使用されています");

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -14,6 +14,14 @@ export default function LoginPage() {
     async function handleSubmit(e) {
         e.preventDefault()
         setError('')
+        if (!identifier.trim()) {
+            setError('ユーザー名またはメールアドレスを入力してください')
+            return
+        }
+        if (!password) {
+            setError('パスワードを入力してください')
+            return
+        }
         setLoading(true)
         try {
             const data = await loginApi({ identifier, password })

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -17,6 +17,14 @@ export default function RegisterPage() {
     async function handleSubmit(e) {
         e.preventDefault()
         setError('')
+        if (!username.trim()) {
+            setError('ユーザー名を入力してください')
+            return
+        }
+        if (!password) {
+            setError('パスワードを入力してください')
+            return
+        }
         if (password !== confirmPassword) {
             setError('パスワードが一致しません')
             return
@@ -41,7 +49,7 @@ export default function RegisterPage() {
                 <input
                     className="auth-input"
                     type="text"
-                    placeholder="ユーザー名（2〜50文字・日本語も使用可）"
+                    placeholder="ユーザー名（2〜50文字・スペース・日本語も使用可）"
                     value={username}
                     onChange={e => setUsername(e.target.value)}
                     required
@@ -60,7 +68,7 @@ export default function RegisterPage() {
                     <input
                         className="auth-input"
                         type={showPassword ? 'text' : 'password'}
-                        placeholder="パスワード（8文字以上・日本語も使用可）"
+                        placeholder="パスワード（8文字以上・英数字・記号）"
                         value={password}
                         onChange={e => setPassword(e.target.value)}
                         required


### PR DESCRIPTION
## 概要

Closes #53

## 変更内容

- **ユーザー名にスペースを許可**: 半角スペース・全角スペース両対応。`Tomas Jon` や `田中　与四郎` のような名前が登録できるようになった
- **全角スペースのトリム対応**: `trim()` → `strip()` に変更し、全角スペースが前後についていても正しく処理する
- **パスワードのプレースホルダー修正**: 「日本語も使用可」を削除。IMEトラブルを避けるためASCII文字を推奨
- **必須バリデーションのJS強化**: ユーザー名・パスワードが空のまま送信された場合、ブラウザデフォルトではなく日本語の明確なエラーメッセージを表示

## テスト観点

- [x] `Tomas Jon`（半角スペースあり）で登録できる
- [x] `田中　与四郎`（全角スペースあり）で登録できる
- [ ] スペースのみのユーザー名は登録拒否される
- [x] ユーザー名空欄でsubmit →「ユーザー名を入力してください」が表示される
- [x] パスワード空欄でsubmit → 「パスワードを入力してください」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)