### PR TITLE
chore: AWSデプロイ基盤を追加（Terraform・Dockerfile・デプロイスクリプト）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Terraform
+infra/terraform/.terraform/
+infra/terraform/terraform.tfstate
+infra/terraform/terraform.tfstate.backup
+infra/terraform/tfplan
+infra/terraform/terraform.tfvars
+infra/terraform/.terraform.lock.hcl
+
+# Frontend
+frontend/node_modules/
+frontend/dist/
+frontend/.env.production
+frontend/.env.local
+
+# Backend
+backend/build/
+backend/.gradle/
+backend/out/
+
+# System
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,33 @@
+# マルチステージビルド
+# ステージ1: ビルド（Gradleでjarファイルを作る）
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /app
+
+# Gradleのキャッシュを活かすため、先にビルドファイルだけコピー
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon
+
+# ソースコードをコピーしてビルド
+COPY src src
+RUN ./gradlew bootJar --no-daemon -x test
+
+# ステージ2: 実行（JREのみ。サイズを小さくする）
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+# セキュリティ: rootではなく専用ユーザーで実行
+RUN addgroup -S spring && adduser -S spring -G spring
+USER spring:spring
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# TaskManagement AWSデプロイスクリプト
+# 使い方: ./infra/deploy.sh
+set -e
+
+# ===== 設定 =====
+AWS_REGION="ap-northeast-1"
+PROJECT_NAME="taskmanagement"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "========================================="
+echo "  TaskManagement AWS デプロイ"
+echo "========================================="
+
+# ===== 前提チェック =====
+echo ""
+echo "[1/6] 前提ツールの確認..."
+command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI がインストールされていません"; exit 1; }
+command -v terraform >/dev/null 2>&1 || { echo "ERROR: terraform がインストールされていません"; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker がインストールされていません"; exit 1; }
+
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "  AWS アカウントID: $AWS_ACCOUNT_ID"
+echo "  リージョン: $AWS_REGION"
+
+# ===== Terraform インフラ作成 =====
+echo ""
+echo "[2/6] Terraform でインフラを構築..."
+cd "$SCRIPT_DIR/terraform"
+
+if [ ! -f "terraform.tfvars" ]; then
+  echo "ERROR: terraform/terraform.tfvars が見つかりません"
+  echo "  terraform.tfvars.example をコピーして設定してください:"
+  echo "  cp terraform.tfvars.example terraform.tfvars"
+  exit 1
+fi
+
+terraform init
+terraform plan -out=tfplan
+echo ""
+echo "上記の変更内容を確認してください。続行しますか？ (yes/no)"
+read -r CONFIRM
+if [ "$CONFIRM" != "yes" ]; then
+  echo "デプロイをキャンセルしました"
+  exit 0
+fi
+
+terraform apply tfplan
+
+# ===== Terraformの出力を取得 =====
+ECR_URL=$(terraform output -raw ecr_repository_url)
+S3_BUCKET=$(terraform output -raw s3_bucket_name)
+CLOUDFRONT_ID=$(terraform output -raw cloudfront_distribution_id)
+BACKEND_URL=$(terraform output -raw backend_url)
+FRONTEND_URL=$(terraform output -raw frontend_url)
+
+# ===== バックエンド Dockerイメージのビルド & プッシュ =====
+echo ""
+echo "[3/6] バックエンド Dockerイメージをビルド..."
+cd "$ROOT_DIR/backend"
+
+# ECRにログイン
+aws ecr get-login-password --region "$AWS_REGION" | \
+  docker login --username AWS --password-stdin "$ECR_URL"
+
+# イメージをビルド
+docker build --platform linux/amd64 -t "$PROJECT_NAME-backend" .
+
+# ECRにプッシュ
+docker tag "$PROJECT_NAME-backend:latest" "$ECR_URL:latest"
+docker push "$ECR_URL:latest"
+echo "  完了: $ECR_URL:latest"
+
+# ===== ECSサービスを再起動（新イメージを反映）=====
+echo ""
+echo "[4/6] ECSサービスを更新..."
+aws ecs update-service \
+  --cluster "${PROJECT_NAME}-cluster" \
+  --service "${PROJECT_NAME}-backend" \
+  --force-new-deployment \
+  --region "$AWS_REGION" \
+  --query 'service.serviceName' \
+  --output text
+
+echo "  ECSデプロイを開始しました（完了まで数分かかります）"
+
+# ===== フロントエンドをビルド & S3にアップロード =====
+echo ""
+echo "[5/6] フロントエンドをビルド & S3にアップロード..."
+cd "$ROOT_DIR/frontend"
+
+# 本番環境用の環境変数を設定
+echo "VITE_API_BASE_URL=$BACKEND_URL" > .env.production
+
+npm ci
+npm run build
+
+# S3にアップロード
+aws s3 sync dist/ "s3://$S3_BUCKET/" --delete
+echo "  S3にアップロード完了"
+
+# ===== CloudFrontキャッシュを削除 =====
+echo ""
+echo "[6/6] CloudFrontキャッシュをクリア..."
+INVALIDATION_ID=$(aws cloudfront create-invalidation \
+  --distribution-id "$CLOUDFRONT_ID" \
+  --paths "/*" \
+  --query 'Invalidation.Id' \
+  --output text)
+echo "  キャッシュ削除リクエスト: $INVALIDATION_ID"
+
+# ===== 完了 =====
+echo ""
+echo "========================================="
+echo "  デプロイ完了！"
+echo "========================================="
+echo ""
+echo "  フロントエンド: $FRONTEND_URL"
+echo "  バックエンドAPI: $BACKEND_URL"
+echo ""
+echo "※ ECSの起動に数分かかる場合があります"
+echo "※ CloudFrontのキャッシュ削除に最大15分かかる場合があります"

--- a/infra/terraform/cloudfront.tf
+++ b/infra/terraform/cloudfront.tf
@@ -1,0 +1,71 @@
+# CloudFront OAC（S3へのアクセス制御）
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project_name}-frontend-oac"
+  description                       = "OAC for frontend S3 bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFrontディストリビューション（CDN = 世界中にコンテンツを高速配信）
+resource "aws_cloudfront_distribution" "frontend" {
+  # S3をオリジン（コンテンツの元）に指定
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+    origin_id                = "S3-${aws_s3_bucket.frontend.bucket}"
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  comment             = "${var.project_name} frontend"
+
+  # デフォルトのキャッシュ動作
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-${aws_s3_bucket.frontend.bucket}"
+    viewer_protocol_policy = "redirect-to-https" # HTTPをHTTPSにリダイレクト
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600  # 1時間キャッシュ
+    max_ttl     = 86400 # 最大1日キャッシュ
+  }
+
+  # React RouterのSPA対応（404 → index.htmlを返す）
+  custom_error_response {
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true # デフォルト証明書（*.cloudfront.netドメイン）
+  }
+
+  tags = {
+    Name        = "${var.project_name}-frontend"
+    Environment = var.environment
+  }
+}

--- a/infra/terraform/ecr.tf
+++ b/infra/terraform/ecr.tf
@@ -1,0 +1,38 @@
+# ECR（Elastic Container Registry）= AWSのDockerイメージ置き場
+# バックエンドのSpring BootをDockerイメージとしてここに保存する
+resource "aws_ecr_repository" "backend" {
+  name                 = "${var.project_name}/backend"
+  image_tag_mutability = "MUTABLE"
+
+  # イメージのセキュリティスキャン（プッシュ時に脆弱性チェック）
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name        = "${var.project_name}-backend"
+    Environment = var.environment
+  }
+}
+
+# 古いイメージを自動削除するライフサイクルポリシー（コスト削減）
+resource "aws_ecr_lifecycle_policy" "backend" {
+  repository = aws_ecr_repository.backend.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "最新10件のみ保持"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -1,0 +1,160 @@
+# CloudWatch ロググループ（アプリのログを保存する場所）
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = "/ecs/${var.project_name}/backend"
+  retention_in_days = 30
+
+  tags = {
+    Name = "${var.project_name}-backend-logs"
+  }
+}
+
+# ECSクラスター（コンテナを動かす「土台」）
+resource "aws_ecs_cluster" "main" {
+  name = "${var.project_name}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = {
+    Name = "${var.project_name}-cluster"
+  }
+}
+
+# ECSタスク定義（コンテナの設定書）
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "${var.project_name}-backend"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"  # 0.5 vCPU
+  memory                   = "1024" # 1 GB
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "backend"
+      image = "${aws_ecr_repository.backend.repository_url}:${var.backend_image_tag}"
+
+      portMappings = [
+        {
+          containerPort = 8080
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "SPRING_PROFILES_ACTIVE"
+          value = "production"
+        },
+        {
+          name  = "SPRING_DATASOURCE_URL"
+          value = "jdbc:postgresql://${aws_db_instance.postgres.endpoint}/${var.db_name}"
+        },
+        {
+          name  = "SPRING_DATASOURCE_USERNAME"
+          value = var.db_username
+        },
+        {
+          name  = "SPRING_DATASOURCE_PASSWORD"
+          value = var.db_password
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.backend.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${var.project_name}-backend-task"
+  }
+}
+
+# ALB（Application Load Balancer）= リクエストをECSに振り分ける
+resource "aws_lb" "main" {
+  name               = "${var.project_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = {
+    Name = "${var.project_name}-alb"
+  }
+}
+
+# ALBターゲットグループ（ECSタスクを登録する先）
+resource "aws_lb_target_group" "backend" {
+  name        = "${var.project_name}-backend-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/actuator/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tags = {
+    Name = "${var.project_name}-backend-tg"
+  }
+}
+
+# ALBリスナー（HTTP 80番でリクエストを受け付ける）
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+# ECSサービス（タスクを常時起動し続ける仕組み）
+resource "aws_ecs_service" "backend" {
+  name            = "${var.project_name}-backend"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = 1 # 起動するコンテナ数（本番は2以上推奨）
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.private[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.backend.arn
+    container_name   = "backend"
+    container_port   = 8080
+  }
+
+  depends_on = [aws_lb_listener.http]
+
+  tags = {
+    Name = "${var.project_name}-backend-service"
+  }
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,61 @@
+# ECSタスク実行ロール（ECSがECRからイメージをプルするための権限）
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.project_name}-ecs-task-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECSタスクロール（アプリケーション自身が他AWSサービスを呼ぶための権限）
+resource "aws_iam_role" "ecs_task" {
+  name = "${var.project_name}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# CloudWatch Logsへの書き込み権限（アプリのログを見るために必要）
+resource "aws_iam_role_policy" "ecs_task_logs" {
+  name = "${var.project_name}-ecs-task-logs"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # デプロイ状態をS3に保存（チーム開発やCI/CDに必要）
+  # 初回はコメントアウトして、後で有効化する
+  # backend "s3" {
+  #   bucket = "taskmanagement-tfstate-<あなたのAWSアカウントID>"
+  #   key    = "terraform.tfstate"
+  #   region = "ap-northeast-1"
+  # }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# CloudFront用（us-east-1 固定。ACM証明書がus-east-1必須のため）
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,31 @@
+# デプロイ後に表示される重要な情報
+output "frontend_url" {
+  description = "フロントエンドのURL（CloudFront）"
+  value       = "https://${aws_cloudfront_distribution.frontend.domain_name}"
+}
+
+output "backend_url" {
+  description = "バックエンドAPIのURL（ALB）"
+  value       = "http://${aws_lb.main.dns_name}"
+}
+
+output "ecr_repository_url" {
+  description = "ECRリポジトリURL（Dockerイメージのプッシュ先）"
+  value       = aws_ecr_repository.backend.repository_url
+}
+
+output "rds_endpoint" {
+  description = "RDSエンドポイント（アプリからの接続先）"
+  value       = aws_db_instance.postgres.endpoint
+  sensitive   = true
+}
+
+output "s3_bucket_name" {
+  description = "フロントエンドのS3バケット名"
+  value       = aws_s3_bucket.frontend.bucket
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFrontディストリビューションID（キャッシュ削除に使用）"
+  value       = aws_cloudfront_distribution.frontend.id
+}

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -1,0 +1,46 @@
+# RDS サブネットグループ（どのサブネットにDBを置くか指定）
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-db-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name = "${var.project_name}-db-subnet-group"
+  }
+}
+
+# RDS PostgreSQL インスタンス
+resource "aws_db_instance" "postgres" {
+  identifier = "${var.project_name}-postgres"
+
+  engine         = "postgres"
+  engine_version = "16.3"
+  instance_class = "db.t3.micro" # 無料枠対象（750時間/月）
+
+  allocated_storage     = 20  # GB
+  max_allocated_storage = 100 # オートスケーリング上限
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  # 本番環境では true にすること
+  skip_final_snapshot = true
+
+  # 自動バックアップ（7日間保持）
+  backup_retention_period = 7
+  backup_window           = "03:00-04:00" # 日本時間 午後12時〜1時
+
+  # メンテナンスウィンドウ
+  maintenance_window = "mon:04:00-mon:05:00"
+
+  # パフォーマンスインサイト（無効 = 無料）
+  performance_insights_enabled = false
+
+  tags = {
+    Name        = "${var.project_name}-postgres"
+    Environment = var.environment
+  }
+}

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -1,0 +1,50 @@
+# S3バケット（フロントエンドの静的ファイルを置く場所）
+resource "aws_s3_bucket" "frontend" {
+  # バケット名はグローバルでユニークである必要がある
+  bucket = "${var.project_name}-frontend-${data.aws_caller_identity.current.account_id}"
+
+  tags = {
+    Name        = "${var.project_name}-frontend"
+    Environment = var.environment
+  }
+}
+
+# パブリックアクセスをブロック（CloudFront経由でのみアクセス）
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3バケットポリシー（CloudFrontからのアクセスのみ許可）
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontOAC"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+}
+
+# AWSアカウント情報の取得
+data "aws_caller_identity" "current" {}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# このファイルをコピーして terraform.tfvars を作成する
+# cp terraform.tfvars.example terraform.tfvars
+#
+# terraform.tfvars は .gitignore に追加すること（パスワードが含まれるため）
+
+aws_region   = "ap-northeast-1"
+project_name = "taskmanagement"
+environment  = "production"
+
+# 必ずランダムで強力なパスワードに変更すること
+db_password = "CHANGE_ME_STRONG_PASSWORD_HERE"
+db_username = "postgres"
+db_name     = "taskmanagement"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,41 @@
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "プロジェクト名（リソース名のプレフィックスに使用）"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "environment" {
+  description = "環境名"
+  type        = string
+  default     = "production"
+}
+
+variable "db_password" {
+  description = "PostgreSQLのパスワード（terraform.tfvarsで設定。Gitにコミットしない）"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_username" {
+  description = "PostgreSQLのユーザー名"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_name" {
+  description = "データベース名"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "backend_image_tag" {
+  description = "バックエンドDockerイメージのタグ"
+  type        = string
+  default     = "latest"
+}

--- a/infra/terraform/vpc.tf
+++ b/infra/terraform/vpc.tf
@@ -1,0 +1,189 @@
+# VPC（仮想プライベートクラウド）= AWSの中の「自分専用ネットワーク」
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.project_name}-vpc"
+    Environment = var.environment
+  }
+}
+
+# インターネットゲートウェイ = VPCをインターネットに繋ぐ「玄関」
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# パブリックサブネット（インターネットから直接アクセス可能）
+# ALB（ロードバランサー）を置く場所。2つのAZに分散（冗長化）
+resource "aws_subnet" "public" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public-${count.index + 1}"
+  }
+}
+
+# プライベートサブネット（インターネットから直接アクセス不可）
+# RDS（DB）とECS（バックエンド）を置く場所
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index + 10}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${var.project_name}-private-${count.index + 1}"
+  }
+}
+
+# ルートテーブル（パブリック）= インターネット行きの経路を定義
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Elastic IP（NATゲートウェイ用）= 固定IPアドレス
+resource "aws_eip" "nat" {
+  domain = "vpc"
+  tags = {
+    Name = "${var.project_name}-nat-eip"
+  }
+}
+
+# NATゲートウェイ = プライベートサブネットからインターネットへの出口
+# （ECSがDockerイメージをプルするために必要）
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.project_name}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ルートテーブル（プライベート）= NATゲートウェイ経由でインターネットへ
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# 利用可能なAZを自動取得
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# セキュリティグループ: ALB用（インターネット→ALBのHTTP/HTTPSを許可）
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb-sg"
+  description = "ALB security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-alb-sg"
+  }
+}
+
+# セキュリティグループ: ECS用（ALBからの8080ポートのみ許可）
+resource "aws_security_group" "ecs" {
+  name        = "${var.project_name}-ecs-sg"
+  description = "ECS task security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-ecs-sg"
+  }
+}
+
+# セキュリティグループ: RDS用（ECSからの5432ポートのみ許可）
+resource "aws_security_group" "rds" {
+  name        = "${var.project_name}-rds-sg"
+  description = "RDS security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  tags = {
+    Name = "${var.project_name}-rds-sg"
+  }
+}


### PR DESCRIPTION
## 概要
ローカル開発環境のアプリをAWSに本番デプロイするための基盤を追加する。

## 変更内容
- `infra/terraform/`: VPC, ECS, ECR, RDS, S3, CloudFront, IAM のTerraform定義
- `infra/deploy.sh`: ECRへのDockerイメージpush・ECSサービス更新・S3フロントエンドデプロイ・CloudFrontキャッシュクリアを自動化するスクリプト
- `backend/Dockerfile`: バックエンドのマルチステージDockerfile（Java 21 / Alpine）
- `.gitignore`: Terraform状態ファイル・`terraform.tfvars`（シークレット含む）を除外

## セキュリティ確認
- `terraform.tfvars`（DBパスワード等）は `.gitignore` で除外済み
- `terraform.tfvars.example` はプレースホルダーのみ（シークレットなし）
- AWSアクセスキー・シークレットキーはファイルに含まれていない

Closes #59