### PR TITLE
chore: フロントエンドのEC2デプロイ環境を整備

### DIFF
--- a/infra/nginx/app.conf
+++ b/infra/nginx/app.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # React Router 対応: 存在しないパスはすべて index.html にフォールバック
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Spring Boot API へのリバースプロキシ
+    # /api/* → localhost:8080 に転送
+    location /api/ {
+        proxy_pass         http://localhost:8080;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/infra/scripts/deploy-frontend.sh
+++ b/infra/scripts/deploy-frontend.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# フロントエンドをビルドしてEC2にデプロイするスクリプト
+# 使い方: bash infra/scripts/deploy-frontend.sh
+#
+# 前提条件:
+#   - terraform apply 済みで EC2 が起動していること
+#   - KEY_PATH 環境変数またはデフォルト (~/.ssh/taskmanagement.pem) にキーペアがあること
+#
+# 例:
+#   KEY_PATH=~/.ssh/my-key.pem bash infra/scripts/deploy-frontend.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+KEY_PATH="${KEY_PATH:-$HOME/.ssh/taskmanagement.pem}"
+TERRAFORM_DIR="$REPO_ROOT/infra/terraform"
+FRONTEND_DIR="$REPO_ROOT/frontend"
+
+echo "=== EC2のIPアドレスを取得 ==="
+EC2_IP=$(terraform -chdir="$TERRAFORM_DIR" output -raw ec2_public_ip)
+echo "EC2 IP: $EC2_IP"
+
+echo "=== フロントエンドをビルド ==="
+cd "$FRONTEND_DIR"
+npm run build
+
+echo "=== ビルド済みファイルをEC2に転送 ==="
+scp -i "$KEY_PATH" \
+    -o StrictHostKeyChecking=no \
+    -r dist/* \
+    "ec2-user@$EC2_IP:/usr/share/nginx/html/"
+
+echo "=== nginxを再読み込み ==="
+ssh -i "$KEY_PATH" \
+    -o StrictHostKeyChecking=no \
+    "ec2-user@$EC2_IP" \
+    "sudo nginx -t && sudo systemctl reload nginx"
+
+echo ""
+echo "デプロイ完了: http://$EC2_IP"

--- a/infra/scripts/deploy-frontend.sh
+++ b/infra/scripts/deploy-frontend.sh
@@ -25,16 +25,18 @@ cd "$FRONTEND_DIR"
 npm run build
 
 echo "=== ビルド済みファイルをEC2に転送 ==="
+# /usr/share/nginx/html/ は root 所有のため、一時ディレクトリ経由で sudo コピー
+ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no "ec2-user@$EC2_IP" "rm -rf /tmp/frontend-dist && mkdir -p /tmp/frontend-dist"
 scp -i "$KEY_PATH" \
     -o StrictHostKeyChecking=no \
     -r dist/* \
-    "ec2-user@$EC2_IP:/usr/share/nginx/html/"
+    "ec2-user@$EC2_IP:/tmp/frontend-dist/"
 
-echo "=== nginxを再読み込み ==="
+echo "=== nginx配信ディレクトリに配置 ==="
 ssh -i "$KEY_PATH" \
     -o StrictHostKeyChecking=no \
     "ec2-user@$EC2_IP" \
-    "sudo nginx -t && sudo systemctl reload nginx"
+    "sudo cp -r /tmp/frontend-dist/* /usr/share/nginx/html/ && sudo nginx -t && sudo systemctl reload nginx"
 
 echo ""
 echo "デプロイ完了: http://$EC2_IP"

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -24,12 +24,9 @@ resource "aws_instance" "main" {
   vpc_security_group_ids      = [aws_security_group.ec2.id]
   associate_public_ip_address = true
 
-  # key_name = var.key_pair_name
-  # ↑ キーペアでSSH接続する場合はコメントを外す
-  # AWSコンソール → EC2 → キーペア で事前に作成が必要
+  key_name = var.key_pair_name
 
   # user_data = インスタンス起動時に自動実行されるスクリプト
-  # Java 21 と nginx をインストールしておく
   user_data = <<-EOF
     #!/bin/bash
     dnf update -y
@@ -39,6 +36,28 @@ resource "aws_instance" "main" {
 
     # nginx（フロントエンドの静的ファイル配信用）
     dnf install -y nginx
+
+    # nginx 設定: /api → Spring Boot リバースプロキシ + React Router SPAフォールバック
+    cat > /etc/nginx/conf.d/app.conf << 'NGINXEOF'
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass         http://localhost:8080;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+NGINXEOF
+
     systemctl enable nginx
     systemctl start nginx
   EOF

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -16,10 +16,10 @@ data "aws_ami" "amazon_linux_2023" {
 }
 
 # EC2インスタンス = AWSのサーバー
-# t2.micro = 無料枠対象（750時間/月、新規アカウントから12ヶ月間）
+# t3.micro = 無料枠対象（750時間/月、新規アカウントから12ヶ月間）
 resource "aws_instance" "main" {
   ami                         = data.aws_ami.amazon_linux_2023.id
-  instance_type               = "t2.micro"
+  instance_type               = "t3.micro"
   subnet_id                   = aws_subnet.public.id
   vpc_security_group_ids      = [aws_security_group.ec2.id]
   associate_public_ip_address = true
@@ -27,18 +27,23 @@ resource "aws_instance" "main" {
   key_name = var.key_pair_name
 
   # user_data = インスタンス起動時に自動実行されるスクリプト
-  user_data = <<-EOF
-    #!/bin/bash
-    dnf update -y
+  # 注意: <<EOF（インデントなし）を使うこと。<<-EOF はタブのみ除去するため
+  #       スペースインデントがあると #!/bin/bash の前に空白が入り cloud-init が実行しない。
+  user_data = <<EOF
+#!/bin/bash
+dnf update -y
 
-    # Java 21（Spring Boot バックエンド用）
-    dnf install -y java-21-amazon-corretto
+# Java 21（Spring Boot バックエンド用）
+dnf install -y java-21-amazon-corretto
 
-    # nginx（フロントエンドの静的ファイル配信用）
-    dnf install -y nginx
+# nginx（フロントエンドの静的ファイル配信用）
+dnf install -y nginx
 
-    # nginx 設定: /api → Spring Boot リバースプロキシ + React Router SPAフォールバック
-    cat > /etc/nginx/conf.d/app.conf << 'NGINXEOF'
+# デフォルトのサーバーブロック（server_name _ on port 80）を削除してapp.confと競合しないようにする
+sed -i '/^    server {/,/^    }$/d' /etc/nginx/nginx.conf
+
+# nginx 設定: /api → Spring Boot リバースプロキシ + React Router SPAフォールバック
+cat > /etc/nginx/conf.d/app.conf << 'NGINXEOF'
 server {
     listen 80;
     server_name _;
@@ -58,9 +63,9 @@ server {
 }
 NGINXEOF
 
-    systemctl enable nginx
-    systemctl start nginx
-  EOF
+systemctl enable nginx
+systemctl start nginx
+EOF
 
   # ルートボリューム（OS用のディスク）
   root_block_device {

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -4,5 +4,8 @@
 aws_region   = "ap-northeast-1"
 project_name = "taskmanagement"
 
-# SSH接続にキーペアを使う場合は以下のコメントを外す
-# key_pair_name = "my-keypair"
+# AWSコンソール → EC2 → キーペア で事前に作成したキーペア名
+key_pair_name = "my-keypair"
+
+# 自分のIPアドレス（curl https://checkip.amazonaws.com で確認）
+allowed_ip = "YOUR_IP/32"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -10,8 +10,12 @@ variable "project_name" {
   default     = "taskmanagement"
 }
 
-# variable "key_pair_name" {
-#   description = "EC2へのSSH接続に使うキーペア名"
-#   description = "AWSコンソール → EC2 → キーペア で事前に作成しておく"
-#   type        = string
-# }
+variable "key_pair_name" {
+  description = "EC2へのSSH接続に使うキーペア名。AWSコンソール → EC2 → キーペア で事前に作成しておく。"
+  type        = string
+}
+
+variable "allowed_ip" {
+  description = "セキュリティグループで許可するIPアドレス（CIDR形式）。curl https://checkip.amazonaws.com で確認。"
+  type        = string
+}

--- a/infra/terraform/vpc.tf
+++ b/infra/terraform/vpc.tf
@@ -61,7 +61,7 @@ resource "aws_security_group" "ec2" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.allowed_ip]
   }
 
   # フロントエンド（nginx が 80番ポートで配信）
@@ -69,7 +69,7 @@ resource "aws_security_group" "ec2" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.allowed_ip]
   }
 
   # バックエンドAPI（Spring Boot が 8080番ポートで動く）
@@ -77,7 +77,7 @@ resource "aws_security_group" "ec2" {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.allowed_ip]
   }
 
   # アウトバウンド（パッケージインストールなど）は全て許可


### PR DESCRIPTION
## 概要

フロントエンドをEC2で動かすために不足していた設定・スクリプトを追加。

## 変更内容

- **infra/nginx/app.conf** — nginx設定ファイル（リファレンス用）
  - `/api/*` → `localhost:8080` へのリバースプロキシ
  - React Router対応のSPAフォールバック（`try_files`）
- **infra/terraform/ec2.tf** — `user_data` に nginx設定を組み込み、`key_pair_name` を有効化
- **infra/terraform/variables.tf** — `key_pair_name` / `allowed_ip` 変数を追加
- **infra/terraform/vpc.tf** — セキュリティグループの `cidr_blocks` を `var.allowed_ip` に統一
- **infra/terraform/terraform.tfvars.example** — `key_pair_name` / `allowed_ip` の記載例を追加
- **infra/scripts/deploy-frontend.sh** — `npm run build` → SCP転送 → `nginx reload` を自動化

## デプロイ手順

```bash
# 1. terraform.tfvars を作成して変数を設定
cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars
# key_pair_name と allowed_ip を編集

# 2. インフラを構築
terraform -chdir=infra/terraform apply

# 3. フロントエンドをデプロイ
KEY_PATH=~/.ssh/<キーペア名>.pem bash infra/scripts/deploy-frontend.sh
```

Closes #65