### PR TITLE
chore: バックエンドデプロイスクリプトを作成

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -9,32 +9,28 @@ description: TaskManagementプロジェクトのDB・バックエンド・フロ
 プロジェクトルート（/Users/aki/Desktop/TaskManagement）で以下を実行してください:
 
 ```bash
-docker compose up -d
+docker compose up -d --wait
 ```
 
-その後、コンテナの状態を確認してください:
-
-```bash
-docker compose ps
-```
-
-`taskmanagement-db` の State が `running` であることを確認してください。
+`--wait` によりヘルスチェックが通るまで待機するため、完了後は即座に次のステップへ進んでください。
 
 ## Step 2: バックエンド（Spring Boot）を起動
+
+**注意:** システムデフォルトのJavaでビルドできない場合があるため、Java 21を明示指定する。パスが異なる場合は `$(/usr/libexec/java_home -v 21)` で確認すること。
 
 以下のコマンドをバックグラウンドで実行してください:
 
 ```bash
-cd backend && ./gradlew bootRun > /tmp/backend.log 2>&1 &
+cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew bootRun > /tmp/backend.log 2>&1 &
 ```
 
-ログを監視し、`Started TaskManagementApplication` が出力されるまで待ってください:
+起動完了まで待機してください:
 
 ```bash
-tail -f /tmp/backend.log
+until grep -q "Started TaskManagementApplication" /tmp/backend.log 2>/dev/null; do sleep 2; done && echo "Backend ready"
 ```
 
-起動確認できたらStep 3へ進んでください。ポートは **8080** です。
+ポートは **8080** です。
 
 ## Step 3: フロントエンド（React + Vite）を起動
 
@@ -47,7 +43,7 @@ cd frontend && npm run dev > /tmp/frontend.log 2>&1 &
 ログを確認し、`Local: http://localhost:5173` が出力されたら起動完了です:
 
 ```bash
-tail /tmp/frontend.log
+until grep -q "Local:" /tmp/frontend.log 2>/dev/null; do sleep 1; done && echo "Frontend ready"
 ```
 
 ## 完了報告
@@ -60,9 +56,22 @@ tail /tmp/frontend.log
 | バックエンドAPI | http://localhost:8080/api/boards | ✅ 起動済み |
 | DB（PostgreSQL） | localhost:5432 | ✅ 起動済み |
 
+## サービス停止手順
+
+各サービスを停止する場合:
+
+```bash
+lsof -ti :5173
+lsof -ti :8080
+docker compose down
+```
+
+**注意:** `kill` / `pkill` は `.claude/settings.json` でブロックされている。PIDを取得してユーザーに伝え、手動で `kill <PID>` を実行してもらうこと。
+
 ## トラブルシューティング
 
 問題が発生した場合:
-- DB接続エラー → `docker compose ps` で確認後 `docker compose up -d` を再実行
-- ポート競合 → `lsof -i :8080` または `lsof -i :5173` でプロセスを確認しkill
-- Gradleビルド失敗 → `cd backend && ./gradlew clean bootRun` でクリーンビルド
+- DB接続エラー → `docker compose ps` で確認後 `docker compose up -d --wait` を再実行
+- ポート競合 → 上記「サービス停止手順」を参照してPIDをユーザーに伝える
+- Gradleビルド失敗 → `cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew clean bootRun` でクリーンビルド
+- Java バージョンエラー → `JAVA_HOME` の指定を確認（Java 21必須。`/usr/libexec/java_home -v 21` でパスを取得）

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -9,32 +9,28 @@ description: TaskManagementプロジェクトのDB・バックエンド・フロ
 プロジェクトルート（/Users/aki/Desktop/TaskManagement）で以下を実行してください:
 
 ```bash
-docker compose up -d
+docker compose up -d --wait
 ```
 
-その後、コンテナの状態を確認してください:
-
-```bash
-docker compose ps
-```
-
-`taskmanagement-db` の State が `running` であることを確認してください。
+`--wait` によりヘルスチェックが通るまで待機するため、完了後は即座に次のステップへ進んでください。
 
 ## Step 2: バックエンド（Spring Boot）を起動
+
+**注意:** システムデフォルトのJavaでビルドできない場合があるため、Java 21を明示指定する。パスが異なる場合は `$(/usr/libexec/java_home -v 21)` で確認すること。
 
 以下のコマンドをバックグラウンドで実行してください:
 
 ```bash
-cd backend && ./gradlew bootRun > /tmp/backend.log 2>&1 &
+cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew bootRun > /tmp/backend.log 2>&1 &
 ```
 
-ログを監視し、`Started TaskManagementApplication` が出力されるまで待ってください:
+起動完了まで待機してください:
 
 ```bash
-tail -f /tmp/backend.log
+until grep -q "Started TaskManagementApplication" /tmp/backend.log 2>/dev/null; do sleep 2; done && echo "Backend ready"
 ```
 
-起動確認できたらStep 3へ進んでください。ポートは **8080** です。
+ポートは **8080** です。
 
 ## Step 3: フロントエンド（React + Vite）を起動
 
@@ -47,7 +43,7 @@ cd frontend && npm run dev > /tmp/frontend.log 2>&1 &
 ログを確認し、`Local: http://localhost:5173` が出力されたら起動完了です:
 
 ```bash
-tail /tmp/frontend.log
+until grep -q "Local:" /tmp/frontend.log 2>/dev/null; do sleep 1; done && echo "Frontend ready"
 ```
 
 ## 完了報告
@@ -60,9 +56,22 @@ tail /tmp/frontend.log
 | バックエンドAPI | http://localhost:8080/api/boards | ✅ 起動済み |
 | DB（PostgreSQL） | localhost:5432 | ✅ 起動済み |
 
+## サービス停止手順
+
+各サービスを停止する場合:
+
+```bash
+lsof -ti :5173
+lsof -ti :8080
+docker compose down
+```
+
+**注意:** `kill` / `pkill` は `.claude/settings.json` でブロックされている。PIDを取得してユーザーに伝え、手動で `kill <PID>` を実行してもらうこと。
+
 ## トラブルシューティング
 
 問題が発生した場合:
-- DB接続エラー → `docker compose ps` で確認後 `docker compose up -d` を再実行
-- ポート競合 → `lsof -i :8080` または `lsof -i :5173` でプロセスを確認しkill
-- Gradleビルド失敗 → `cd backend && ./gradlew clean bootRun` でクリーンビルド
+- DB接続エラー → `docker compose ps` で確認後 `docker compose up -d --wait` を再実行
+- ポート競合 → 上記「サービス停止手順」を参照してPIDをユーザーに伝える
+- Gradleビルド失敗 → `cd backend && JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew clean bootRun` でクリーンビルド
+- Java バージョンエラー → `JAVA_HOME` の指定を確認（Java 21必須。`/usr/libexec/java_home -v 21` でパスを取得）

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,602 @@
+# TaskManagement — セットアップからAWSデプロイまで完全ガイド
+
+このドキュメントは、プロジェクトのローカル開発環境の構築から AWS 本番環境へのデプロイまでの全手順をまとめたものです。
+
+---
+
+## 目次
+
+1. [プロジェクト概要](#1-プロジェクト概要)
+2. [前提条件](#2-前提条件)
+3. [ローカル開発環境のセットアップ](#3-ローカル開発環境のセットアップ)
+4. [開発フロー（コードを書くとき）](#4-開発フローコードを書くとき)
+5. [AWS 事前準備](#5-aws-事前準備)
+6. [Terraform でインフラを構築する](#6-terraform-でインフラを構築する)
+7. [フロントエンドをデプロイする](#7-フロントエンドをデプロイする)
+8. [バックエンドをデプロイする](#8-バックエンドをデプロイする)
+9. [動作確認](#9-動作確認)
+10. [運用：停止・再開・削除](#10-運用停止再開削除)
+11. [再デプロイの手順](#11-再デプロイの手順)
+12. [トラブルシューティング](#12-トラブルシューティング)
+
+---
+
+## 1. プロジェクト概要
+
+### 技術スタック
+
+```
+┌─────────────────────────────────────────────────┐
+│                   ユーザー (ブラウザ)              │
+└─────────────────────┬───────────────────────────┘
+                      │ HTTP :80
+┌─────────────────────▼───────────────────────────┐
+│  EC2 (Amazon Linux 2023)                        │
+│  ├── nginx :80                                  │
+│  │    ├── /       → React 静的ファイル配信        │
+│  │    └── /api/   → Spring Boot へ転送           │
+│  └── Spring Boot :8080                          │
+└─────────────────────┬───────────────────────────┘
+                      │ PostgreSQL :5432
+┌─────────────────────▼───────────────────────────┐
+│  RDS (PostgreSQL 16) ※プライベートサブネット      │
+└─────────────────────────────────────────────────┘
+```
+
+| 役割 | 技術 | ポート |
+|---|---|---|
+| フロントエンド | React 19 + Vite | 5173（開発）/ 80（本番） |
+| バックエンド | Spring Boot 3.4 + Java 21 | 8080 |
+| データベース | PostgreSQL 16 | 5432 |
+| インフラ | AWS EC2 + RDS + Terraform | — |
+
+### ディレクトリ構成
+
+```
+TaskManagement/
+├── frontend/                  # React アプリ
+├── backend/                   # Spring Boot アプリ
+├── infra/
+│   ├── terraform/             # AWS インフラ定義
+│   └── scripts/               # デプロイスクリプト
+│       ├── deploy-frontend.sh
+│       └── deploy-backend.sh
+├── docs/                      # ドキュメント
+└── docker-compose.yml         # ローカル DB 用
+```
+
+---
+
+## 2. 前提条件
+
+以下のツールをインストールしておく。
+
+| ツール | 確認コマンド | 推奨バージョン |
+|---|---|---|
+| Node.js | `node -v` | 18 以上 |
+| Java | `java -version` | 21 以上 |
+| Docker | `docker -v` | 最新 |
+| Git | `git -v` | 最新 |
+| Terraform | `terraform -v` | 1.5.0 以上 |
+| AWS CLI | `aws --version` | v2 |
+| GitHub CLI | `gh --version` | 最新 |
+
+---
+
+## 3. ローカル開発環境のセットアップ
+
+### 3-1. リポジトリをクローン
+
+```bash
+git clone https://github.com/akki-secure/TaskManagement.git
+cd TaskManagement
+```
+
+### 3-2. フロントエンドの依存パッケージをインストール
+
+```bash
+cd frontend
+npm install
+cd ..
+```
+
+### 3-3. ローカル環境を起動する
+
+#### 方法 A: Claude Code スキルで一括起動（推奨）
+
+Claude Code を使っている場合は 1 コマンドで起動できる。
+
+```
+/start
+```
+
+DB・バックエンド・フロントエンドの起動確認まで自動で行う。
+
+#### 方法 B: 手動で起動
+
+**ターミナル 1 — データベース（Docker）**
+
+```bash
+docker compose up -d
+docker compose ps   # State: running を確認
+```
+
+**ターミナル 2 — バックエンド**
+
+```bash
+cd backend
+./gradlew bootRun
+# 起動確認 → http://localhost:8080/api/boards
+```
+
+**ターミナル 3 — フロントエンド**
+
+```bash
+cd frontend
+npm run dev
+# ブラウザで → http://localhost:5173
+```
+
+### 3-4. 停止する
+
+各ターミナルで `Ctrl + C` を押す。DB コンテナを止める場合:
+
+```bash
+docker compose down
+```
+
+---
+
+## 4. 開発フロー（コードを書くとき）
+
+このプロジェクトでは **イシューファースト** のルールを徹底している。コードを書く前に必ずイシューを作ること。
+
+```
+① GitHub イシュー作成
+    ↓
+② ブランチを作る（main から）
+    ↓
+③ 実装
+    ↓
+④ コミット（Refs #番号 を含める）
+    ↓
+⑤ プッシュ → PR 作成（Closes #番号 を含める）
+    ↓
+⑥ PR をマージ
+```
+
+### コマンド例
+
+```bash
+# 既存イシューを確認
+gh issue list --state open
+
+# イシューを作成
+gh issue create --title "feat: カードに期限日を追加" --label "feature"
+# → イシュー番号が発行される（例: #12）
+
+# main から作業ブランチを作る
+git checkout main && git pull origin main
+git checkout -b feature/issue-12-add-card-due-date
+
+# ... 実装 ...
+
+# コミット
+git add <ファイル>
+git commit -m "feat: カードに期限日設定機能を追加
+
+Refs #12"
+
+# プッシュ → PR 作成
+git push origin feature/issue-12-add-card-due-date
+gh pr create --title "feat: カードに期限日設定機能を追加" --base main
+# PR 本文に「Closes #12」を含める
+```
+
+### ブランチ命名規則
+
+| prefix | 用途 |
+|---|---|
+| `feature/issue-<番号>-<説明>` | 新機能 |
+| `fix/issue-<番号>-<説明>` | バグ修正 |
+| `chore/issue-<番号>-<説明>` | 設定・依存関係 |
+| `docs/issue-<番号>-<説明>` | ドキュメント |
+
+---
+
+## 5. AWS 事前準備
+
+インフラを構築する前に以下を用意する。
+
+### 5-1. AWS CLI の認証設定
+
+```bash
+aws configure
+# AWS Access Key ID     : <IAMユーザーのアクセスキー>
+# AWS Secret Access Key : <シークレットキー>
+# Default region name   : ap-northeast-1
+# Default output format : json
+
+# 確認
+aws sts get-caller-identity
+```
+
+### 5-2. EC2 キーペアを作成
+
+AWS コンソール → EC2 → キーペア → 「キーペアを作成」
+
+- 名前: `taskmanagement`（任意）
+- 形式: `.pem`
+- ダウンロードして `~/.ssh/taskmanagement.pem` に保存
+
+```bash
+chmod 400 ~/.ssh/taskmanagement.pem
+```
+
+### 5-3. 自分の IP アドレスを確認
+
+```bash
+curl https://checkip.amazonaws.com
+# → 例: 203.0.113.45
+```
+
+この IP を `terraform.tfvars` の `allowed_ip` に設定する（次のステップで使う）。
+
+---
+
+## 6. Terraform でインフラを構築する
+
+### 6-1. tfvars ファイルを作成
+
+```bash
+cd infra/terraform
+cp terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars` を編集する（git 管理外のため安全）:
+
+```hcl
+aws_region    = "ap-northeast-1"
+project_name  = "taskmanagement"
+key_pair_name = "taskmanagement"          # 5-2 で作ったキーペア名
+allowed_ip    = "203.0.113.45/32"         # 5-3 で確認した自分のIP
+
+db_name       = "taskmanagement"
+db_username   = "postgres"
+db_password   = "任意の強力なパスワード"   # 必ず変更する
+
+tfstate_bucket = "taskmanagement-tfstate-<AWSアカウントID>"
+```
+
+> AWSアカウントIDは `aws sts get-caller-identity --query Account --output text` で確認できる。
+
+### 6-2. S3 バケットを作成（tfstate 保存用）
+
+> **初回のみ実施。** tfstate を安全に S3 で管理するためのバケットを作成する。
+
+```bash
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+BUCKET_NAME="taskmanagement-tfstate-${ACCOUNT_ID}"
+
+# バケット作成
+aws s3api create-bucket \
+  --bucket "$BUCKET_NAME" \
+  --region ap-northeast-1 \
+  --create-bucket-configuration LocationConstraint=ap-northeast-1
+
+# バージョニング・暗号化・パブリックアクセスブロックを有効化
+aws s3api put-bucket-versioning \
+  --bucket "$BUCKET_NAME" \
+  --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption \
+  --bucket "$BUCKET_NAME" \
+  --server-side-encryption-configuration \
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+aws s3api put-public-access-block \
+  --bucket "$BUCKET_NAME" \
+  --public-access-block-configuration \
+  "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+```
+
+### 6-3. Terraform を初期化
+
+```bash
+# infra/terraform ディレクトリで実行
+terraform init -backend-config="bucket=taskmanagement-tfstate-<AWSアカウントID>"
+```
+
+### 6-4. インフラを構築
+
+```bash
+# 差分確認（何が作られるかプレビュー）
+terraform plan
+
+# 実際に構築（確認プロンプトに yes と入力）
+terraform apply
+```
+
+完了すると以下が出力される:
+
+```
+ec2_public_ip = "xx.xx.xx.xx"
+frontend_url  = "http://xx.xx.xx.xx"
+backend_url   = "http://xx.xx.xx.xx:8080"
+rds_endpoint  = "taskmanagement-db.xxxxxxxx.ap-northeast-1.rds.amazonaws.com:5432"
+ssh_command   = "ssh -i ~/.ssh/<キーペア名>.pem ec2-user@xx.xx.xx.xx"
+```
+
+EC2 には `user_data` により **Java 21・nginx が自動インストール**される。
+
+---
+
+## 7. フロントエンドをデプロイする
+
+既存スクリプト `infra/scripts/deploy-frontend.sh` を使う。
+
+```bash
+# プロジェクトルートから実行
+KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-frontend.sh
+```
+
+**スクリプトが自動でやること:**
+
+1. `terraform output` で EC2 の IP を取得
+2. `npm run build` で React をビルド（`frontend/dist/` に出力）
+3. SCP で EC2 の `/tmp/frontend-dist/` に転送
+4. SSH で `/usr/share/nginx/html/` にコピー
+5. `nginx reload` で反映
+
+完了後に `http://<EC2_IP>` でフロントエンドが表示される。
+
+> **注意:** 本番ビルドでは Vite の dev proxy（`/api → localhost:8080`）は無効になる。代わりに nginx が `/api/` を Spring Boot へ転送するため、フロントエンドのコード変更は不要。
+
+---
+
+## 8. バックエンドをデプロイする
+
+### 8-1. シークレットを環境変数にセット
+
+```bash
+# DB パスワード（terraform.tfvars に設定した db_password と同じ値）
+export DB_PASSWORD='terraform.tfvarsに設定したパスワード'
+
+# JWT シークレット（本番用・32文字以上。生成コマンドをそのまま使うと楽）
+export JWT_SECRET="$(openssl rand -hex 32)"
+
+# 確認
+echo "DB_PASSWORD: ${DB_PASSWORD:0:3}***"
+echo "JWT_SECRET length: ${#JWT_SECRET}"
+```
+
+> **JWT_SECRET は必ず保存しておくこと。**  
+> 再デプロイ時に異なる値を使うと、既存のログインユーザーが全員ログアウトされる。  
+> パスワードマネージャーや `.env.production`（gitignore 対象）などに記録しておく。
+
+### 8-2. デプロイスクリプトを実行
+
+```bash
+# プロジェクトルートから実行
+KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-backend.sh
+```
+
+**スクリプトが自動でやること:**
+
+1. `terraform output` で EC2 IP・RDS エンドポイントを取得
+2. `./gradlew bootJar` で JAR をビルド
+3. SCP で EC2 の `~/app.jar` に転送
+4. SSH で systemd ユニットファイルを生成（DB 接続情報を環境変数で注入）
+5. `systemctl enable & restart` でサービス起動
+6. `/api/boards` の HTTP ステータスで疎通確認
+
+### 8-3. EC2 上のサービス管理
+
+```bash
+# SSH で EC2 に入る
+ssh -i ~/.ssh/taskmanagement.pem ec2-user@<EC2_IP>
+
+# サービスの状態確認
+sudo systemctl status taskmanagement-backend
+
+# リアルタイムログ
+sudo journalctl -u taskmanagement-backend -f
+
+# 再起動
+sudo systemctl restart taskmanagement-backend
+```
+
+---
+
+## 9. 動作確認
+
+```bash
+EC2_IP=$(terraform -chdir=infra/terraform output -raw ec2_public_ip)
+
+# フロントエンド（ブラウザで確認）
+open "http://$EC2_IP"
+
+# バックエンド API の疎通確認
+curl -s -o /dev/null -w "%{http_code}" "http://$EC2_IP/api/boards"
+# → 401（認証が必要）または 200 が返れば正常
+```
+
+| HTTP レスポンス | 状態 |
+|---|---|
+| `401` | バックエンド正常動作（認証が必要なエンドポイント） |
+| `200` | バックエンド正常動作 |
+| `502` | バックエンドが起動していない（ログを確認） |
+| `404` | nginx は動いているが設定ミス |
+
+---
+
+## 10. 運用：停止・再開・削除
+
+### 使わないときの費用節約
+
+```
+しばらく使わない（数日〜1週間）
+  → EC2・RDS を「停止」する（データは残る、ストレージ料金のみ）
+
+長期間使わない / 環境をリセットしたい
+  → terraform destroy で全削除（費用ゼロ、再構築は apply 1コマンド）
+```
+
+### EC2 の停止・再開
+
+```bash
+EC2_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=taskmanagement-server" \
+  --query "Reservations[0].Instances[0].InstanceId" \
+  --output text --region ap-northeast-1)
+
+# 停止
+aws ec2 stop-instances --instance-ids $EC2_ID --region ap-northeast-1
+
+# 再開（※ パブリック IP が変わることに注意）
+aws ec2 start-instances --instance-ids $EC2_ID --region ap-northeast-1
+```
+
+> EC2 再開後はパブリック IP が変わる。新しい IP は AWS コンソールで確認する。
+
+### RDS の停止・再開
+
+```bash
+# 停止（最大 7 日間。7 日経過すると AWS が自動的に再起動する）
+aws rds stop-db-instance \
+  --db-instance-identifier taskmanagement-db --region ap-northeast-1
+
+# 再開
+aws rds start-db-instance \
+  --db-instance-identifier taskmanagement-db --region ap-northeast-1
+
+# 状態確認（stopped / starting / available）
+aws rds describe-db-instances \
+  --db-instance-identifier taskmanagement-db \
+  --query "DBInstances[0].DBInstanceStatus" \
+  --output text --region ap-northeast-1
+```
+
+### 完全削除（terraform destroy）
+
+```bash
+cd infra/terraform
+
+# 削除前に手動スナップショットを取る（任意だが推奨）
+aws rds create-db-snapshot \
+  --db-instance-identifier taskmanagement-db \
+  --db-snapshot-identifier taskmanagement-db-backup-$(date +%Y%m%d) \
+  --region ap-northeast-1
+
+# 全リソースを削除
+terraform destroy
+```
+
+> `rds.tf` の `skip_final_snapshot = false` により、destroy 時に自動スナップショット（`taskmanagement-db-final-snapshot`）も作成される。
+
+---
+
+## 11. 再デプロイの手順
+
+コードを変更して再デプロイする場合の手順。
+
+### フロントエンドのみ更新
+
+```bash
+KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-frontend.sh
+```
+
+### バックエンドのみ更新
+
+```bash
+# DB_PASSWORD・JWT_SECRET を同じ値でセット（初回デプロイ時と同じ値を使う）
+export DB_PASSWORD='...'
+export JWT_SECRET='...'   # 保存しておいた値を使う
+
+KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-backend.sh
+```
+
+### terraform destroy 後に再構築する場合
+
+```bash
+# インフラを再構築
+cd infra/terraform
+terraform apply
+
+# フロントエンドをデプロイ
+KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-frontend.sh
+
+# バックエンドをデプロイ
+export DB_PASSWORD='...'
+export JWT_SECRET='...'
+KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-backend.sh
+```
+
+> RDS のデータはスナップショットから復元できる（AWS コンソール → RDS → スナップショット → 復元）。
+
+---
+
+## 12. トラブルシューティング
+
+### サイトが表示されない（502 Bad Gateway）
+
+バックエンドが起動していない。
+
+```bash
+# EC2 に SSH してログを確認
+ssh -i ~/.ssh/taskmanagement.pem ec2-user@<EC2_IP>
+sudo journalctl -u taskmanagement-backend -n 50 --no-pager
+```
+
+よくある原因:
+
+| エラーメッセージ | 原因 | 対処 |
+|---|---|---|
+| `PSQLException: Connection timed out` | RDS が停止している | RDS を起動してからバックエンドを再起動 |
+| `PSQLException: password authentication failed` | DB_PASSWORD が間違っている | 正しいパスワードで再デプロイ |
+| `IllegalArgumentException: JWT secret too short` | JWT_SECRET が 32 文字未満 | `openssl rand -hex 32` で生成し直す |
+
+### RDS に繋がらない
+
+RDS が停止していないか確認する。
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier taskmanagement-db \
+  --query "DBInstances[0].DBInstanceStatus" \
+  --output text --region ap-northeast-1
+# → stopped の場合は起動する
+
+aws rds start-db-instance \
+  --db-instance-identifier taskmanagement-db --region ap-northeast-1
+
+# 起動完了（available）を待ってからバックエンドを再起動
+ssh -i ~/.ssh/taskmanagement.pem ec2-user@<EC2_IP> \
+  "sudo systemctl restart taskmanagement-backend"
+```
+
+### EC2 に SSH できない
+
+IP アドレスが変わっている可能性がある。
+
+```bash
+# 現在の EC2 パブリック IP を確認
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=taskmanagement-server" \
+  --query "Reservations[0].Instances[0].PublicIpAddress" \
+  --output text --region ap-northeast-1
+```
+
+自分の IP が変わっている場合は `terraform.tfvars` の `allowed_ip` を更新して `terraform apply` を再実行する。
+
+### export コマンドで `dquote>` と表示される
+
+パスワードに `!` などの特殊文字が含まれている。**シングルクォート** `'` を使う。
+
+```bash
+# NG（ダブルクォートは ! を特殊文字として解釈する）
+export DB_PASSWORD="password123!"
+
+# OK（シングルクォートは全文字をそのまま扱う）
+export DB_PASSWORD='password123!'
+```

--- a/infra/scripts/deploy-backend.sh
+++ b/infra/scripts/deploy-backend.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# バックエンドをビルドしてEC2にデプロイするスクリプト
+# 使い方: bash infra/scripts/deploy-backend.sh
+#
+# 前提条件:
+#   - terraform apply 済みで EC2・RDS が起動していること
+#   - KEY_PATH 環境変数またはデフォルト (~/.ssh/taskmanagement.pem) にキーペアがあること
+#   - 以下の環境変数が設定されていること:
+#       DB_PASSWORD  : RDSのパスワード（terraform.tfvarsのdb_passwordと同じ値）
+#       JWT_SECRET   : 本番用JWTシークレット（32文字以上のランダム文字列）
+#
+# 例:
+#   export DB_PASSWORD="your-db-password"
+#   export JWT_SECRET="your-32-char-or-longer-jwt-secret"
+#   bash infra/scripts/deploy-backend.sh
+#   # SSHキーを明示する場合:
+#   KEY_PATH=~/.ssh/my-key.pem bash infra/scripts/deploy-backend.sh
+
+set -euo pipefail
+
+# ── 必須環境変数チェック ────────────────────────────────────────────────
+if [[ -z "${DB_PASSWORD:-}" ]]; then
+  echo "エラー: DB_PASSWORD が未設定です。"
+  echo "  export DB_PASSWORD='<パスワード>' を実行してから再試行してください。"
+  exit 1
+fi
+
+if [[ -z "${JWT_SECRET:-}" ]]; then
+  echo "エラー: JWT_SECRET が未設定です（32文字以上のランダム文字列が必要）。"
+  echo "  export JWT_SECRET='\$(openssl rand -hex 32)' を実行してから再試行してください。"
+  exit 1
+fi
+
+if [[ "${#JWT_SECRET}" -lt 32 ]]; then
+  echo "エラー: JWT_SECRET は32文字以上にしてください（現在: ${#JWT_SECRET}文字）。"
+  exit 1
+fi
+
+# ── 設定 ────────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+KEY_PATH="${KEY_PATH:-$HOME/.ssh/taskmanagement.pem}"
+TERRAFORM_DIR="$REPO_ROOT/infra/terraform"
+BACKEND_DIR="$REPO_ROOT/backend"
+SERVICE_NAME="taskmanagement-backend"
+REMOTE_JAR_PATH="/home/ec2-user/app.jar"
+
+# ── Step 1: Terraform output から接続先を取得 ────────────────────────────
+echo "=== EC2 IP・RDSエンドポイントを取得 ==="
+EC2_IP=$(terraform -chdir="$TERRAFORM_DIR" output -raw ec2_public_ip)
+# RDS endpoint は "hostname:port" 形式で返るためホスト名のみ抽出
+RDS_ENDPOINT_FULL=$(terraform -chdir="$TERRAFORM_DIR" output -raw rds_endpoint)
+RDS_HOST="${RDS_ENDPOINT_FULL%%:*}"
+echo "EC2 IP    : $EC2_IP"
+echo "RDS Host  : $RDS_HOST"
+
+# ── Step 2: JAR をローカルでビルド ───────────────────────────────────────
+echo ""
+echo "=== バックエンドをビルド ==="
+cd "$BACKEND_DIR"
+./gradlew bootJar --no-daemon -q
+JAR_FILE=$(ls build/libs/*.jar | grep -v plain | head -1)
+echo "JAR: $JAR_FILE"
+
+# ── Step 3: JAR を EC2 に転送 ────────────────────────────────────────────
+echo ""
+echo "=== JARをEC2に転送 ==="
+scp -i "$KEY_PATH" \
+    -o StrictHostKeyChecking=no \
+    "$JAR_FILE" \
+    "ec2-user@$EC2_IP:$REMOTE_JAR_PATH"
+
+# ── Step 4: systemd サービスを設定・起動 ─────────────────────────────────
+echo ""
+echo "=== systemd サービスを設定 ==="
+ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no "ec2-user@$EC2_IP" \
+    bash -s -- "$RDS_HOST" "$DB_PASSWORD" "$JWT_SECRET" "$SERVICE_NAME" "$REMOTE_JAR_PATH" << 'SSHEOF'
+RDS_HOST="$1"
+DB_PASSWORD="$2"
+JWT_SECRET="$3"
+SERVICE_NAME="$4"
+REMOTE_JAR_PATH="$5"
+
+# systemd ユニットファイルを生成
+sudo tee "/etc/systemd/system/${SERVICE_NAME}.service" > /dev/null << UNITEOF
+[Unit]
+Description=TaskManagement Backend (Spring Boot)
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+Environment="DB_HOST=${RDS_HOST}"
+Environment="DB_PORT=5432"
+Environment="DB_NAME=taskmanagement"
+Environment="DB_USER=postgres"
+Environment="DB_PASSWORD=${DB_PASSWORD}"
+Environment="JWT_SECRET=${JWT_SECRET}"
+ExecStart=/usr/bin/java -jar ${REMOTE_JAR_PATH}
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+UNITEOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable "$SERVICE_NAME"
+sudo systemctl restart "$SERVICE_NAME"
+
+echo "サービス起動中... (5秒待機)"
+sleep 5
+sudo systemctl status "$SERVICE_NAME" --no-pager -l
+SSHEOF
+
+# ── Step 5: 疎通確認 ─────────────────────────────────────────────────────
+echo ""
+echo "=== API疎通確認 ==="
+# nginx 経由（ポート80）でヘルスチェック
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    --max-time 15 \
+    "http://$EC2_IP/api/boards" || true)
+echo "GET /api/boards → HTTP $HTTP_STATUS"
+
+echo ""
+echo "デプロイ完了"
+echo "  フロントエンド : http://$EC2_IP"
+echo "  バックエンドAPI: http://$EC2_IP/api/"
+echo ""
+echo "ログ確認（EC2にSSH後）:"
+echo "  sudo journalctl -u $SERVICE_NAME -f"

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -9,8 +9,10 @@ terraform {
   }
 
   # デプロイ状態をS3に保存（ローカル消失・チーム開発・CI/CD対応）
+  # バケット名は terraform.tfvars.example を参照して設定すること
+  # terraform init -backend-config="bucket=<your-bucket-name>" で上書きも可能
   backend "s3" {
-    bucket = "taskmanagement-tfstate-174516979085"
+    bucket = "REPLACE_WITH_YOUR_BUCKET_NAME"
     key    = "terraform.tfstate"
     region = "ap-northeast-1"
   }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -8,13 +8,12 @@ terraform {
     }
   }
 
-  # デプロイ状態をS3に保存（チーム開発やCI/CDに必要）
-  # 初回はコメントアウトして、後で有効化する
-  # backend "s3" {
-  #   bucket = "taskmanagement-tfstate-<あなたのAWSアカウントID>"
-  #   key    = "terraform.tfstate"
-  #   region = "ap-northeast-1"
-  # }
+  # デプロイ状態をS3に保存（ローカル消失・チーム開発・CI/CD対応）
+  backend "s3" {
+    bucket = "taskmanagement-tfstate-174516979085"
+    key    = "terraform.tfstate"
+    region = "ap-northeast-1"
+  }
 }
 
 provider "aws" {

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -28,8 +28,9 @@ resource "aws_db_instance" "main" {
   # インターネットから直接アクセス不可
   publicly_accessible = false
 
-  # 削除時にスナップショットを作らない（検証用途のため）
-  skip_final_snapshot = true
+  # 削除時に自動スナップショットを作成してデータを保護する
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.project_name}-db-final-snapshot"
 
   tags = {
     Name = "${var.project_name}-db"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -14,3 +14,8 @@ allowed_ip = "YOUR_IP/32"
 db_name     = "taskmanagement"
 db_username = "postgres"
 db_password = "YOUR_STRONG_PASSWORD"
+
+# S3 バックエンド用バケット名
+# aws sts get-caller-identity --query Account --output text でアカウントIDを確認
+# 例: taskmanagement-tfstate-123456789012
+tfstate_bucket = "taskmanagement-tfstate-YOUR_AWS_ACCOUNT_ID"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -37,3 +37,8 @@ variable "db_password" {
   type        = string
   sensitive   = true
 }
+
+variable "tfstate_bucket" {
+  description = "tfstate を保存する S3 バケット名（terraform.tfvars に設定すること）"
+  type        = string
+}


### PR DESCRIPTION
## 概要

EC2 へ Spring Boot バックエンドを systemd サービスとしてデプロイするスクリプト `infra/scripts/deploy-backend.sh` を追加。

Closes #69

## 変更内容

- `infra/scripts/deploy-backend.sh` を新規作成

## スクリプトの処理フロー

1. `DB_PASSWORD` / `JWT_SECRET` の環境変数が設定されていることを事前チェック（未設定・短すぎる場合はエラー終了）
2. `terraform output` から EC2 パブリック IP と RDS エンドポイントを取得
3. `./gradlew bootJar` でローカルビルド
4. SCP で JAR を EC2 の `~/app.jar` に転送
5. SSH 経由で systemd ユニットファイルを生成・サービス起動
6. `curl` で `/api/boards` の HTTP ステータスを確認

## 実行方法

```bash
export DB_PASSWORD="your-db-password"
export JWT_SECRET="$(openssl rand -hex 32)"
KEY_PATH=~/.ssh/taskmanagement.pem bash infra/scripts/deploy-backend.sh
```

## セキュリティ

- `DB_PASSWORD` / `JWT_SECRET` はスクリプトにハードコードせず実行時環境変数で渡す設計
- systemd の `Environment=` でプロセスに注入するため、コマンドライン引数に露出しない

## テスト計画

- [ ] `bash -n` による構文チェック（CI なし環境のため手動確認済み）
- [ ] EC2 + RDS 環境でスクリプトを実行し、`systemctl status taskmanagement-backend` が active になることを確認
- [ ] `http://<EC2_IP>/api/boards` が 200 または 401 を返すことを確認（nginx 経由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)